### PR TITLE
[Feature] 일반 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	// email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/greeni/api/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/ErrorStatus.java
@@ -14,6 +14,10 @@ public enum ErrorStatus {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+    // 회원 관련 응답
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 존재하는 메일입니다"),
+    EXPIRED_CODE(HttpStatus.BAD_REQUEST, "MEMBER4002", "이메일 인증코드가 만료되었습니다"),
+    WRONG_CODE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일 인증코드가 올바르지 않습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus {
     EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 존재하는 메일입니다"),
     EXPIRED_CODE(HttpStatus.BAD_REQUEST, "MEMBER4002", "이메일 인증코드가 만료되었습니다"),
     WRONG_CODE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일 인증코드가 올바르지 않습니다"),
+    NOT_SEND_EMAIL_CODE(HttpStatus.BAD_REQUEST, "MEMBER4004", "이메일 인증코드 전송에 실패했습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/config/EmailConfig.java
+++ b/src/main/java/com/greeni/api/config/EmailConfig.java
@@ -1,0 +1,61 @@
+package com.greeni.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        // 추가 설정(인증, 암호화, 타임아웃 등)
+        mailSender.setJavaMailProperties(getMailProperties());
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.starttls.required", starttlsRequired);
+        props.put("mail.smtp.timeout", timeout);
+        return props;
+    }
+
+
+}

--- a/src/main/java/com/greeni/api/config/RedisConfig.java
+++ b/src/main/java/com/greeni/api/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.greeni.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/greeni/api/config/SecurityConfig.java
+++ b/src/main/java/com/greeni/api/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.greeni.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    public static final String[] AUTH_WHITELIST = {
+            "/v2/api-docs",
+            "/v3/api-docs/**",
+            "/configuration/ui",
+            "/swagger-resources/**",
+            "/configuration/security",
+            "/swagger-ui.html",
+            "/webjars/**",
+            "/file/**",
+            "/images/**",
+            "/css/**",
+            "/js/**",
+            "/swagger/**",
+            "/swagger-ui/**",
+            "/swagger-ui/index.html",
+            "/favicon.ico",
+            "/h2/**"
+    };
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/members/signup", "/api/members/email").permitAll()
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(AbstractHttpConfigurer::disable)   // 로그인 폼 비활성화
+            .httpBasic(AbstractHttpConfigurer::disable);  // 기본 인증 팝업 비활성화
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/greeni/api/members/controller/MemberController.java
+++ b/src/main/java/com/greeni/api/members/controller/MemberController.java
@@ -1,12 +1,33 @@
 package com.greeni.api.members.controller;
 
 import com.greeni.api.apiPayload.ApiResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.greeni.api.apiPayload.status.SuccessStatus;
+import com.greeni.api.members.dto.MemberRequestDTO;
+import com.greeni.api.members.dto.MemberResponseDTO;
+import com.greeni.api.members.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
+@RequiredArgsConstructor
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<MemberResponseDTO.toJoinResultDTO>> signUp(@RequestBody @Valid MemberRequestDTO.SignUpDTO request){
+        MemberResponseDTO.toJoinResultDTO result = memberService.signUpMember(request);
+        return new ResponseEntity<>(ApiResponse.created(result),HttpStatus.CREATED);
+    }
+
+    @PostMapping("/email")
+    public ResponseEntity<ApiResponse<?>> emailRequest(@RequestBody @Valid MemberRequestDTO.EmailDTO request){
+        memberService.sendEmail(request);
+        return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
+    }
 
 }

--- a/src/main/java/com/greeni/api/members/converter/MemberConverter.java
+++ b/src/main/java/com/greeni/api/members/converter/MemberConverter.java
@@ -1,4 +1,25 @@
 package com.greeni.api.members.converter;
 
+import com.greeni.api.members.domain.Member;
+import com.greeni.api.members.dto.MemberRequestDTO;
+import com.greeni.api.members.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.time.LocalDateTime;
+
 public class MemberConverter {
+
+    public static Member toMember(MemberRequestDTO.SignUpDTO request){
+        return Member.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+    }
+
+    public static MemberResponseDTO.toJoinResultDTO toJoinResultDTO(Member member){
+        return MemberResponseDTO.toJoinResultDTO.builder()
+                .memberId(member.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/greeni/api/members/domain/Member.java
+++ b/src/main/java/com/greeni/api/members/domain/Member.java
@@ -31,4 +31,8 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Profile> profileList = new ArrayList<>();
 
+    public void encodePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
@@ -4,14 +4,20 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class MemberRequestDTO {
 
     @Getter
+    @NoArgsConstructor
     public static class SignUpDTO{
 
         @NotBlank(message = "이메일은 필수 입력입니다.")
         @Email
+        @Pattern(
+                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
+                message = "유효한 이메일 도메인만 입력하세요."
+        )
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력입니다.")
@@ -26,10 +32,15 @@ public class MemberRequestDTO {
     }
 
     @Getter
+    @NoArgsConstructor
     public static class EmailDTO {
 
         @NotBlank(message = "이메일은 필수 입력입니다.")
         @Email
+        @Pattern(
+                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
+                message = "유효한 이메일 도메인만 입력하세요."
+        )
         private String email;
     }
 

--- a/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
@@ -1,4 +1,36 @@
 package com.greeni.api.members.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
 public class MemberRequestDTO {
+
+    @Getter
+    public static class SignUpDTO{
+
+        @NotBlank(message = "이메일은 필수 입력입니다.")
+        @Email
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력입니다.")
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$",
+                message = "비밀번호는 8~15자이며, 영문자, 숫자, 특수문자를 모두 포함해야 합니다."
+        )
+        private String password;
+
+        @NotBlank(message = "인증 코드는 필수 입력입니다.")
+        private String code;
+    }
+
+    @Getter
+    public static class EmailDTO {
+
+        @NotBlank(message = "이메일은 필수 입력입니다.")
+        @Email
+        private String email;
+    }
+
 }

--- a/src/main/java/com/greeni/api/members/dto/MemberResponseDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberResponseDTO.java
@@ -1,4 +1,20 @@
 package com.greeni.api.members.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
 public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class toJoinResultDTO{
+        Long memberId;
+        LocalDateTime createdAt;
+    }
 }

--- a/src/main/java/com/greeni/api/members/repository/MemberRepository.java
+++ b/src/main/java/com/greeni/api/members/repository/MemberRepository.java
@@ -4,4 +4,6 @@ import com.greeni.api.members.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/greeni/api/members/service/MemberService.java
+++ b/src/main/java/com/greeni/api/members/service/MemberService.java
@@ -1,9 +1,108 @@
 package com.greeni.api.members.service;
 
+import com.greeni.api.apiPayload.exception.GeneralException;
+import com.greeni.api.apiPayload.status.ErrorStatus;
+import com.greeni.api.members.converter.MemberConverter;
+import com.greeni.api.members.domain.Member;
+import com.greeni.api.members.dto.MemberRequestDTO;
+import com.greeni.api.members.dto.MemberResponseDTO;
+import com.greeni.api.members.repository.MemberRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional
+@Slf4j
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final JavaMailSender javaMailSender;
+    private final RedisTemplate<String, Object> redistemplate;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public MemberResponseDTO.toJoinResultDTO signUpMember(MemberRequestDTO.SignUpDTO request) {
+        // 해당 메일이 이미 존재하는 메일인지 확인
+        if(memberRepository.existsByEmail(request.getEmail())){
+            throw new GeneralException(ErrorStatus.EXIST_EMAIL);
+        }
+
+        // 이메일 인증 완료 여부 확인
+        ValueOperations<String, Object> ops = redistemplate.opsForValue();
+        String codeNum = (String) ops.get("EmailCode"+request.getEmail());
+        if(codeNum == null){
+            throw new GeneralException(ErrorStatus.EXPIRED_CODE);
+        }
+        if(!codeNum.equals(request.getCode())){
+            throw new GeneralException(ErrorStatus.WRONG_CODE);
+        }
+
+        Member member = MemberConverter.toMember(request);
+        member.encodePassword(bCryptPasswordEncoder.encode(member.getPassword()));
+        memberRepository.save(member);
+
+        return MemberConverter.toJoinResultDTO(member);
+    }
+
+    // 이메일 인증 번호 전송
+    public void sendEmail(MemberRequestDTO.EmailDTO request) {
+        int number = (int)(Math.random() * 90000)+100000;
+
+        try{
+            MimeMessage message = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper helper = new MimeMessageHelper(message, true,  "UTF-8");
+            helper.setSubject("[Greeni] 이메일 인증 번호");
+            helper.setTo(request.getEmail());
+            helper.setFrom(new InternetAddress("greeni@greeni.com", "greeni", "UTF-8"));
+
+            String body = "";
+            body += "<!DOCTYPE html>";
+            body += "<html lang='ko'>";
+            body += "<head><meta charset='UTF-8'></head>";
+            body += "<body style='margin:0;padding:0;background-color:#f6f7f8;font-family:sans-serif;'>";
+
+            body += "<div style='width:100%;padding:30px 0;'>";
+            body += "  <div style='max-width:600px;margin:0 auto;background:#ffffff;"
+                    + "border-radius:8px;padding:30px;box-shadow:0 4px 12px rgba(0,0,0,0.08);'>";
+
+            body += "    <h3 style='margin-top:0;color:#333;'>Greeni의 인증번호입니다.</h3>";
+            body += "    <h1 style='font-size:32px;color:#2d3748;text-align:center;margin:20px 0;'>"
+                    + number + "</h1>";
+            body += "    <p style='font-size:15px;color:#555;line-height:1.6;'>"
+                    + "화면으로 돌아가 인증번호를 입력해주세요<br/>"
+                    + "인증번호는 발송된 시점부터 <b>3분</b> 동안 유효합니다.<br/>"
+                    + "유효시간 내 인증을 완료하지 않을 경우 재요청이 필요합니다."
+                    + "</p>";
+
+            body += "  </div>";
+            body += "</div>";
+
+            body += "</body></html>";
+
+            helper.setText(body, true);
+
+            javaMailSender.send(message);
+        } catch(MessagingException | UnsupportedEncodingException e){
+            log.error("Error Sending email", e);
+        }
+
+        // redis에 인증번호 3분간 저장
+        ValueOperations<String, Object> ops = redistemplate.opsForValue();
+        ops.set("EmailCode"+request.getEmail(), number+"", 180, TimeUnit.SECONDS);
+    }
+
 }

--- a/src/main/java/com/greeni/api/members/service/MemberService.java
+++ b/src/main/java/com/greeni/api/members/service/MemberService.java
@@ -102,7 +102,7 @@ public class MemberService {
 
         // redis에 인증번호 3분간 저장
         ValueOperations<String, Object> ops = redistemplate.opsForValue();
-        ops.set("EmailCode"+request.getEmail(), number+"", 180, TimeUnit.SECONDS);
+        ops.set("EmailCode"+request.getEmail(), number+"", 200, TimeUnit.SECONDS);
     }
 
 }

--- a/src/main/java/com/greeni/api/members/service/MemberService.java
+++ b/src/main/java/com/greeni/api/members/service/MemberService.java
@@ -98,6 +98,7 @@ public class MemberService {
             javaMailSender.send(message);
         } catch(MessagingException | UnsupportedEncodingException e){
             log.error("Error Sending email", e);
+            throw new GeneralException(ErrorStatus.NOT_SEND_EMAIL_CODE);
         }
 
         // redis에 인증번호 3분간 저장

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,16 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 100
     show-sql: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PW}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
+            required: true


### PR DESCRIPTION
## 💡 관련 이슈
- #3 

## 📢 작업 내용
- 일반 회원가입 구현
- 이메일 인증 로직 구현
- EmailConfig, RedisConfig, SecurityConfig 작성

## 🗨️ 리뷰 요구사항(선택)
- 프론트 측에 문의 결과 이메일 인증 확인 절차가 가입하기 버튼을 누를 때 진행된다고 하셔서 인증번호 확인 절차를 회원가입 API 안에 넣었습니다.
- 이메일과 Redis 관련 부분 application.yml 파일에 추가했습니다. 노션 확인 부탁드립니다. 