### PR TITLE
[FIX] 프로필 생성/수정 API 수정

### DIFF
--- a/src/main/java/com/greeni/api/apiPayload/status/ProfileErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/ProfileErrorStatus.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ProfileErrorStatus implements ErrorReason {
 
     INVALID_PROFILE_DATA(HttpStatus.BAD_REQUEST, "PROFILE4001", "프로필 정보가 유효하지 않습니다."),
+    PROFILE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PROFILE4002", "프로필은 최대 6개까지 생성할 수 있습니다."),
     UNAUTHORIZED_PROFILE_ACCESS(HttpStatus.FORBIDDEN, "PROFILE4031", "해당 프로필에 접근할 권한이 없습니다."),
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "PROFILE4041", "존재하지 않는 프로필입니다.");
 

--- a/src/main/java/com/greeni/api/profiles/docs/ProfileControllerDocs.java
+++ b/src/main/java/com/greeni/api/profiles/docs/ProfileControllerDocs.java
@@ -24,6 +24,7 @@ public interface ProfileControllerDocs {
             responses = {
                     @ApiResponse(responseCode = "COMMON201", description = "리소스를 생성했습니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileResponseDTO.CreateProfileResponse.class))),
+                    @ApiResponse(responseCode = "PROFILE4002", description = "프로필은 최대 6개까지 생성할 수 있습니다."),
                     @ApiResponse(responseCode = "MEMBER4041", description = "존재하지 않는 회원입니다.")
 
             })

--- a/src/main/java/com/greeni/api/profiles/domain/Profile.java
+++ b/src/main/java/com/greeni/api/profiles/domain/Profile.java
@@ -71,7 +71,8 @@ public class Profile extends BaseEntity {
     }
 
     // 프로필 수정 편의 메서드
-    public void update(String name, LocalDate birth) {
+    public void update(String profileImage, String name, LocalDate birth) {
+        this.profileImage = profileImage;
         this.name = name;
         this.birth = birth;
     }

--- a/src/main/java/com/greeni/api/profiles/dto/ProfileRequestDTO.java
+++ b/src/main/java/com/greeni/api/profiles/dto/ProfileRequestDTO.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 public class ProfileRequestDTO {
 
     public record CreateProfileRequest(
+            @Schema(description = "프로필 이미지", example = "greeni.jpg")
             String profileImage,
 
             @NotBlank(message = "이름은 필수 입력입니다.")
@@ -25,6 +26,9 @@ public class ProfileRequestDTO {
     ) {}
 
     public record UpdateProfileRequest(
+            @Schema(description = "프로필 이미지", example = "greeni.jpg")
+            String profileImage,
+
             @NotBlank(message = "이름은 필수 입력입니다.")
             @Size(min = 1, max = 20, message = "이름은 1~20자 사이여야 합니다.")
             @Schema(description = "수정할 사용자 이름", example = "개굴개굴")

--- a/src/main/java/com/greeni/api/profiles/repository/ProfileRepository.java
+++ b/src/main/java/com/greeni/api/profiles/repository/ProfileRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
+    int countByMemberId(Long memberId);
+
     List<Profile> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
+++ b/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
@@ -31,6 +31,12 @@ public class ProfileServiceImpl implements ProfileService {
     @Override
     @Transactional
     public ProfileResponseDTO.CreateProfileResponse createProfile(Long memberId, ProfileRequestDTO.CreateProfileRequest dto) {
+        // 프로필 생성 가능 개수는 최대 6개
+        int count = profileRepository.countByMemberId(memberId);
+        if (count >= 6) {
+            throw new GeneralException(ProfileErrorStatus.PROFILE_LIMIT_EXCEEDED);
+        }
+
         // Member, Profile 엔티티 생성
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(MemberErrorStatus.NOT_EXIST_MEMBER));

--- a/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
+++ b/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
@@ -63,7 +63,7 @@ public class ProfileServiceImpl implements ProfileService {
         }
 
         // 업데이트
-        profile.update(dto.name(), dto.birth());
+        profile.update(dto.profileImage(), dto.name(), dto.birth());
 
         // DTO 변환 후 반환
         return ProfileConverter.toUpdateProfileResponseDTO(profile);


### PR DESCRIPTION
## 💡 관련 이슈

- #37 

## 📢 작업 내용

- 프로필 생성 시 최대 6개까지만 허용하도록 수정
- 프로필 수정 시 프로필 이미지도 변경 가능하도록 수정

## 🗨️ 리뷰 요구사항(선택)

- 