### PR TITLE
[FEATURE] 프로필 단일 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/greeni/api/profiles/controller/ProfileController.java
+++ b/src/main/java/com/greeni/api/profiles/controller/ProfileController.java
@@ -63,4 +63,14 @@ public class ProfileController implements ProfileControllerDocs {
         ProfileResponseDTO.GetProfileListResponse result = profileService.getProfileList(customUserDetails.getId());
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
+
+    // 프로필 단일 조회
+    @GetMapping("/{profileId}")
+    public ResponseEntity<CommonResponse<ProfileResponseDTO.GetProfileResponse>> findProfile(
+            @PathVariable Long profileId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        ProfileResponseDTO.GetProfileResponse result = profileService.getProfile(customUserDetails.getId(), profileId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/greeni/api/profiles/converter/ProfileConverter.java
+++ b/src/main/java/com/greeni/api/profiles/converter/ProfileConverter.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class ProfileConverter {
 
-    // entity -> DTO
+    // entity -> 생성 응답 DTO
     public static ProfileResponseDTO.CreateProfileResponse toCreateProfileResponseDTO(Profile profile) {
         return ProfileResponseDTO.CreateProfileResponse.builder()
                 .profileId(profile.getId())
@@ -53,6 +53,16 @@ public class ProfileConverter {
                                 .profileImage(profile.getProfileImage())
                                 .build())
                         .toList())
+                .build();
+    }
+
+    // entity -> 조회 응답 DTO
+    public static ProfileResponseDTO.GetProfileResponse toGetProfileResponseDTO(Profile profile) {
+        return ProfileResponseDTO.GetProfileResponse.builder()
+                .profileId(profile.getId())
+                .profileImage(profile.getProfileImage())
+                .name(profile.getName())
+                .birth(profile.getBirth())
                 .build();
     }
 }

--- a/src/main/java/com/greeni/api/profiles/docs/ProfileControllerDocs.java
+++ b/src/main/java/com/greeni/api/profiles/docs/ProfileControllerDocs.java
@@ -30,7 +30,7 @@ public interface ProfileControllerDocs {
             })
     ResponseEntity<CommonResponse<ProfileResponseDTO.CreateProfileResponse>> addProfile(
             @RequestBody @Valid ProfileRequestDTO.CreateProfileRequest dto,
-            @AuthenticationPrincipal CustomUserDetails customUsersDetails
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     );
 
     @Operation(summary = "프로필 수정 API",
@@ -38,6 +38,7 @@ public interface ProfileControllerDocs {
             responses = {
                     @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileResponseDTO.UpdateProfileResponse.class))),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
                     @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다.")
             })
     ResponseEntity<CommonResponse<ProfileResponseDTO.UpdateProfileResponse>> changeProfile(
@@ -52,7 +53,8 @@ public interface ProfileControllerDocs {
             responses = {
                     @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommonResponse.class))),
-                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다.")
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다.")
             })
     ResponseEntity<CommonResponse<Void>> removeProfile(
             @Parameter(description = "삭제할 프로필의 ID", required = true)
@@ -67,6 +69,20 @@ public interface ProfileControllerDocs {
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileResponseDTO.GetProfileListResponse.class))),
             })
     ResponseEntity<CommonResponse<ProfileResponseDTO.GetProfileListResponse>> findProfileList(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+
+    @Operation(summary = "프로필 단일 조회 API",
+            description = "사용자의 프로필을 조회하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProfileResponseDTO.GetProfileResponse.class))),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다.")
+            })
+    ResponseEntity<CommonResponse<ProfileResponseDTO.GetProfileResponse>> findProfile(
+            @Parameter(description = "조회할 프로필의 ID", required = true)
+            @PathVariable Long profileId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     );
 }

--- a/src/main/java/com/greeni/api/profiles/dto/ProfileResponseDTO.java
+++ b/src/main/java/com/greeni/api/profiles/dto/ProfileResponseDTO.java
@@ -39,4 +39,12 @@ public class ProfileResponseDTO {
             String name,
             String profileImage
     ) {}
+
+    @Builder
+    public record GetProfileResponse (
+            Long profileId,
+            String profileImage,
+            String name,
+            LocalDate birth
+    ) {}
 }

--- a/src/main/java/com/greeni/api/profiles/service/ProfileService.java
+++ b/src/main/java/com/greeni/api/profiles/service/ProfileService.java
@@ -16,4 +16,7 @@ public interface ProfileService {
 
     // 프로필 목록 조회
     ProfileResponseDTO.GetProfileListResponse getProfileList(Long memberId);
+
+    // 프로필 단일 조회
+    ProfileResponseDTO.GetProfileResponse getProfile(Long memberId, Long profileId);
 }

--- a/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
+++ b/src/main/java/com/greeni/api/profiles/service/ProfileServiceImpl.java
@@ -59,7 +59,7 @@ public class ProfileServiceImpl implements ProfileService {
 
         // 이 Profile이 현재 로그인한 회원의 것인지 검증
         if (!profile.getMember().getId().equals(memberId)) {
-            throw new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND);
+            throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
 
         // 업데이트
@@ -75,7 +75,7 @@ public class ProfileServiceImpl implements ProfileService {
     public void deleteProfile(Long memberId, Long profileId) {
         // Profile 엔티티 조회
         Profile profile = profileRepository.findById(profileId)
-                .orElseThrow(() -> new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS));
+                .orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
 
         // 본인 Profile인지 검증
         if (!profile.getMember().getId().equals(memberId)) {
@@ -94,5 +94,21 @@ public class ProfileServiceImpl implements ProfileService {
 
         // DTO 변환 후 반환
         return ProfileConverter.toGetProfileListResponseDTO(profiles);
+    }
+
+    // 프로필 단일 조회
+    @Override
+    public ProfileResponseDTO.GetProfileResponse getProfile(Long memberId, Long profileId) {
+        // Profile 엔티티 조회
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
+
+        // 본인 Profile인지 검증
+        if (!profile.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
+
+        // DTO 변환 후 반환
+        return ProfileConverter.toGetProfileResponseDTO(profile);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈

- #33 

## 📢 작업 내용

- 프로필 단일 조회 API 구현
- 프로필 목록 조회 API 문서 추가
- 프로필 접근 시 엔티티 조회 / 권한 검증 오류 처리 기준 통일

## 🧹기타 변경 사항

- MongoDB 의존성 제거

## 🗨️ 리뷰 요구사항(선택)

- 