### PR TITLE
[FEATURE] 월별 일기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
@@ -1,0 +1,18 @@
+package com.greeni.api.apiPayload.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum DiaryErrorStatus implements ErrorReason {
+
+    FUTURE_TIME(HttpStatus.BAD_REQUEST, "DIARY4001", "미래의 연/월입니다."),
+    INVALID_MONTH(HttpStatus.BAD_REQUEST, "DIARY4002", "유효하지 않은 월입니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum DiaryErrorStatus implements ErrorReason {
 
     FUTURE_TIME(HttpStatus.BAD_REQUEST, "DIARY4001", "미래의 연/월입니다."),
-    INVALID_MONTH(HttpStatus.BAD_REQUEST, "DIARY4002", "유효하지 않은 월입니다"),
+    INVALID_MONTH(HttpStatus.BAD_REQUEST, "DIARY4002", "월은 1과 12 사이의 숫자이어야 합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
+++ b/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
@@ -1,7 +1,15 @@
 package com.greeni.api.diaries.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.greeni.api.apiPayload.CommonResponse;
+import com.greeni.api.diaries.dto.DiaryRequestDTO;
+import com.greeni.api.diaries.dto.DiaryResponseDTO;
+import com.greeni.api.diaries.service.DiaryService;
+import com.greeni.api.security.jwt.userDetails.CustomUserDetails;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import com.greeni.api.diaries.controller.docs.DiaryControllerDocs;
 
@@ -13,4 +21,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/diaries")
 @RequiredArgsConstructor
 public class DiaryController implements DiaryControllerDocs {
+
+    private final DiaryService diaryService;
+
+    // 월별 일기 조회
+    @GetMapping("/month")
+    public ResponseEntity<CommonResponse<DiaryResponseDTO.MonthDiaryListDTO>> findMonthDiaryList(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                                                 @RequestParam int year,
+                                                                                                 @RequestParam int month,
+                                                                                                 @RequestParam Long profileId){
+        DiaryResponseDTO.MonthDiaryListDTO result = diaryService.getMonthDiaryList(year, month, customUserDetails.getId(),profileId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
@@ -1,7 +1,34 @@
 package com.greeni.api.diaries.controller.docs;
 
+import com.greeni.api.apiPayload.CommonResponse;
+import com.greeni.api.diaries.dto.DiaryResponseDTO;
+import com.greeni.api.profiles.dto.ProfileResponseDTO;
+import com.greeni.api.security.jwt.userDetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Diary", description = "일기 CRU API")
 public interface DiaryControllerDocs {
+
+    @Operation(summary = "월별 일기 목록 조회 API",
+            description = "월별 일기의 목록을 조회하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponseDTO.MonthDiaryListDTO.class))),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다."),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "DIARY4001", description = "미래의 연/월입니다."),
+                    @ApiResponse(responseCode = "DIARY4002", description = "월은 1과 12 사이의 숫자이어야 합니다.")
+
+            })
+    ResponseEntity<CommonResponse<DiaryResponseDTO.MonthDiaryListDTO>> findMonthDiaryList(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                                                 @RequestParam int year,
+                                                                                                 @RequestParam int month,
+                                                                                                 @RequestParam Long profileId);
 }

--- a/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
+++ b/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
@@ -1,4 +1,24 @@
 package com.greeni.api.diaries.converter;
 
+import com.greeni.api.diaries.domain.Diary;
+import com.greeni.api.diaries.dto.DiaryResponseDTO;
+
+import java.util.List;
+
 public class DiaryConverter {
+
+    public static DiaryResponseDTO.MonthDiaryListDTO toMonthDiaryListDTO(Long profileId, List<Diary> diaryList){
+        List<DiaryResponseDTO.MonthDiaryDTO> result = diaryList.stream()
+                .map(diary -> DiaryResponseDTO.MonthDiaryDTO.builder()
+                        .day(diary.getCreatedAt().getDayOfMonth())
+                        .emotion(diary.getEmotion())
+                        .build()
+                )
+                .toList();
+
+        return DiaryResponseDTO.MonthDiaryListDTO.builder()
+                .profileId(profileId)
+                .diaries(result)
+                .build();
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
@@ -1,4 +1,30 @@
 package com.greeni.api.diaries.dto;
 
+import com.greeni.api.diaries.domain.enums.Emotion;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
 public class DiaryResponseDTO {
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class MonthDiaryListDTO{
+        Long profileId;
+        List<MonthDiaryDTO> diaries;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class MonthDiaryDTO{
+        Emotion emotion;
+        int day;
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
+++ b/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
@@ -3,7 +3,12 @@ package com.greeni.api.diaries.repository;
 import com.greeni.api.diaries.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     int countByProfileId(Long profileId);
+
+    List<Diary> findByProfileIdAndCreatedAtBetweenOrderByCreatedAtAsc(Long profileId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
+++ b/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
@@ -10,5 +10,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     int countByProfileId(Long profileId);
 
-    List<Diary> findByProfileIdAndCreatedAtBetweenOrderByCreatedAtAsc(Long profileId, LocalDateTime start, LocalDateTime end);
+    List<Diary> findByProfileIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(Long profileId, LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -1,4 +1,8 @@
 package com.greeni.api.diaries.service;
 
+import com.greeni.api.diaries.dto.DiaryResponseDTO;
+
 public interface DiaryService {
+
+    DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -1,14 +1,69 @@
 package com.greeni.api.diaries.service;
 
+import com.greeni.api.apiPayload.handler.GeneralException;
+import com.greeni.api.apiPayload.status.DiaryErrorStatus;
+import com.greeni.api.apiPayload.status.ProfileErrorStatus;
+import com.greeni.api.diaries.converter.DiaryConverter;
+import com.greeni.api.diaries.domain.Diary;
+import com.greeni.api.diaries.dto.DiaryResponseDTO;
+import com.greeni.api.diaries.repository.DiaryRepository;
+import com.greeni.api.profiles.domain.Profile;
+import com.greeni.api.profiles.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class DiaryServiceImpl implements DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final ProfileRepository profileRepository;
+
+    @Override
+    public DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId) {
+
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
+
+        // member의 profile인지 검증
+        if (!profile.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
+
+        // 월 검증
+        if(month < 1 || month > 12){
+            throw new GeneralException(DiaryErrorStatus.INVALID_MONTH);
+        }
+
+        // 년도 검증
+        YearMonth requestYm = YearMonth.of(year, month);
+        YearMonth nowYm = YearMonth.now(ZoneId.of("Asia/Seoul"));
+
+        if (requestYm.isAfter(nowYm)) {
+            throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
+        }
+
+
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.plusMonths(1);
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.atStartOfDay();
+
+        List<Diary> diaryList = diaryRepository.findByProfileIdAndCreatedAtBetweenOrderByCreatedAtAsc(profileId, start, end);
+        return DiaryConverter.toMonthDiaryListDTO(profileId, diaryList);
+    }
+
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -11,9 +11,9 @@ import com.greeni.api.profiles.domain.Profile;
 import com.greeni.api.profiles.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,6 +31,7 @@ public class DiaryServiceImpl implements DiaryService {
     private final ProfileRepository profileRepository;
 
     @Override
+    @Transactional(readOnly=true)
     public DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId) {
 
         Profile profile = profileRepository.findById(profileId)
@@ -54,15 +55,13 @@ public class DiaryServiceImpl implements DiaryService {
             throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
         }
 
-
-
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.plusMonths(1);
 
         LocalDateTime start = startDate.atStartOfDay();
         LocalDateTime end = endDate.atStartOfDay();
 
-        List<Diary> diaryList = diaryRepository.findByProfileIdAndCreatedAtBetweenOrderByCreatedAtAsc(profileId, start, end);
+        List<Diary> diaryList = diaryRepository.findByProfileIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(profileId, start, end);
         return DiaryConverter.toMonthDiaryListDTO(profileId, diaryList);
     }
 


### PR DESCRIPTION
## 💡 관련 이슈

- #46 

## 📢 작업 내용

- 월별 일기 목록을 조회하는 API 구현
  - 날짜별로 그날의 감정을 조회
  - 해당 회원의 프로필인지 확인 
  - 연도와 월 검증

## 🗨️ 리뷰 요구사항(선택)

- 