### PR TITLE
[FEAT] 일별 활동요약 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/greeni/api/activities/controller/ActivityController.java
+++ b/src/main/java/com/greeni/api/activities/controller/ActivityController.java
@@ -1,9 +1,18 @@
 package com.greeni.api.activities.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.greeni.api.activities.controller.docs.ActivityControllerDocs;
+import com.greeni.api.activities.dto.ActivityResponseDTO;
+import com.greeni.api.activities.service.ActivityService;
+import com.greeni.api.apiPayload.CommonResponse;
+import com.greeni.api.security.jwt.userDetails.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,4 +22,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/activites")
 @RequiredArgsConstructor
 public class ActivityController implements ActivityControllerDocs {
+
+	private final ActivityService activityService;
+
+	@Override
+	@GetMapping("/day")
+	public ResponseEntity<CommonResponse<ActivityResponseDTO.DailyList>> getDailyActivityList(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@RequestParam Long profileId) {
+		ActivityResponseDTO.DailyList result = activityService
+			.getDailyActivityList(customUserDetails.getId(), profileId);
+		return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/greeni/api/activities/controller/docs/ActivityControllerDocs.java
+++ b/src/main/java/com/greeni/api/activities/controller/docs/ActivityControllerDocs.java
@@ -1,7 +1,34 @@
 package com.greeni.api.activities.controller.docs;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.greeni.api.activities.dto.ActivityResponseDTO;
+import com.greeni.api.apiPayload.CommonResponse;
+import com.greeni.api.security.jwt.userDetails.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Activity", description = "활동내역 CR API")
+@Tag(name = "Activity", description = "활동요약 CR API")
 public interface ActivityControllerDocs {
+
+	@Operation(
+		summary = "일별 활동요약 목록 조회 API",
+		description = "일별 활동요약을 최대 3개까지 보여주는 API / 활동요약이 없다면 빈 리스트를 반환",
+		responses = {
+			@ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+				content = @Content(mediaType = "application/json", schema = @Schema(implementation = ActivityResponseDTO.DailyList.class))),
+			@ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+			@ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다.")
+		})
+	ResponseEntity<CommonResponse<ActivityResponseDTO.DailyList>> getDailyActivityList(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@Parameter(description = "조회할 프로필 ID", required = true) @RequestParam Long profileId
+	);
 }

--- a/src/main/java/com/greeni/api/activities/converter/ActivityConverter.java
+++ b/src/main/java/com/greeni/api/activities/converter/ActivityConverter.java
@@ -1,4 +1,21 @@
 package com.greeni.api.activities.converter;
 
+import java.util.Collections;
+import java.util.List;
+
+import com.greeni.api.activities.domain.Activity;
+import com.greeni.api.activities.dto.ActivityResponseDTO;
+
 public class ActivityConverter {
+
+	public static ActivityResponseDTO.DailyList toDailyActivityListResponseDTO(List<Activity> activityList) {
+
+		if (activityList.isEmpty()) {
+			return new ActivityResponseDTO.DailyList(Collections.emptyList());
+		}
+
+		return new ActivityResponseDTO.DailyList(
+			activityList.stream().map(Activity::getDescription).toList()
+		);
+	}
 }

--- a/src/main/java/com/greeni/api/activities/domain/Activity.java
+++ b/src/main/java/com/greeni/api/activities/domain/Activity.java
@@ -1,14 +1,28 @@
 package com.greeni.api.activities.domain;
 
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.greeni.api.activities.domain.enums.ActivityType;
 import com.greeni.api.common.base.BaseEntity;
 import com.greeni.api.profiles.domain.Profile;
 
-import jakarta.persistence.*;
-import lombok.*;
-
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
@@ -27,8 +41,10 @@ public class Activity extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private ActivityType activityType;
 
+	@Column(nullable = false)
 	private String name;
 
+	@Column(nullable = false)
 	private String description;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/greeni/api/activities/dto/ActivityResponseDTO.java
+++ b/src/main/java/com/greeni/api/activities/dto/ActivityResponseDTO.java
@@ -1,4 +1,14 @@
 package com.greeni.api.activities.dto;
 
+import java.util.List;
+
+import lombok.Builder;
+
 public class ActivityResponseDTO {
+
+	@Builder
+	public record DailyList(
+		List<String> ActivityList
+	) {
+	}
 }

--- a/src/main/java/com/greeni/api/activities/repository/ActivityRepository.java
+++ b/src/main/java/com/greeni/api/activities/repository/ActivityRepository.java
@@ -1,7 +1,15 @@
 package com.greeni.api.activities.repository;
 
-import com.greeni.api.activities.domain.Activity;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.greeni.api.activities.domain.Activity;
+import com.greeni.api.profiles.domain.Profile;
+
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+	List<Activity> findTop3ByProfileAndCreatedAtBetweenOrderByCreatedAtDesc(
+		Profile profile, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/greeni/api/activities/service/ActivityService.java
+++ b/src/main/java/com/greeni/api/activities/service/ActivityService.java
@@ -1,4 +1,7 @@
 package com.greeni.api.activities.service;
 
+import com.greeni.api.activities.dto.ActivityResponseDTO;
+
 public interface ActivityService {
+	ActivityResponseDTO.DailyList getDailyActivityList(Long memberId, Long profileId);
 }

--- a/src/main/java/com/greeni/api/activities/service/ActivityServiceImpl.java
+++ b/src/main/java/com/greeni/api/activities/service/ActivityServiceImpl.java
@@ -1,7 +1,21 @@
 package com.greeni.api.activities.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.greeni.api.activities.converter.ActivityConverter;
+import com.greeni.api.activities.domain.Activity;
+import com.greeni.api.activities.dto.ActivityResponseDTO;
+import com.greeni.api.activities.repository.ActivityRepository;
+import com.greeni.api.apiPayload.handler.GeneralException;
+import com.greeni.api.apiPayload.status.ProfileErrorStatus;
+import com.greeni.api.profiles.domain.Profile;
+import com.greeni.api.profiles.repository.ProfileRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,4 +25,28 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Transactional
 public class ActivityServiceImpl implements ActivityService {
+
+	private final ActivityRepository activityRepository;
+	private final ProfileRepository profileRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public ActivityResponseDTO.DailyList getDailyActivityList(Long memberId, Long profileId) {
+
+		Profile profile = profileRepository.findById(profileId)
+			.orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
+
+		if (!profile.getMember().getId().equals(memberId)) {
+			throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+		}
+
+		LocalDate today = LocalDate.now();
+		LocalDateTime startTime = today.atStartOfDay();
+		LocalDateTime endTime = today.atTime(LocalTime.MAX);
+
+		List<Activity> activityList = activityRepository
+			.findTop3ByProfileAndCreatedAtBetweenOrderByCreatedAtDesc(profile, startTime, endTime);
+
+		return ActivityConverter.toDailyActivityListResponseDTO(activityList);
+	}
 }

--- a/src/main/java/com/greeni/api/security/auth/controller/AuthController.java
+++ b/src/main/java/com/greeni/api/security/auth/controller/AuthController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.greeni.api.apiPayload.CommonResponse;
-import com.greeni.api.security.auth.docs.AuthControllerDocs;
+import com.greeni.api.security.auth.controller.docs.AuthControllerDocs;
 import com.greeni.api.security.auth.dto.AuthRequestDTO;
 import com.greeni.api.security.auth.dto.AuthResponseDTO;
 import com.greeni.api.security.auth.service.AuthService;

--- a/src/main/java/com/greeni/api/security/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/greeni/api/security/auth/controller/docs/AuthControllerDocs.java
@@ -1,4 +1,4 @@
-package com.greeni.api.security.auth.docs;
+package com.greeni.api.security.auth.controller.docs;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,7 +24,7 @@ public interface AuthControllerDocs {
 		summary = "로그인 API",
 		description = "사용자의 이메일과 비밀번호로 로그인을 진행하는 API",
 		responses = {
-			@ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다..",
+			@ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
 				content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponseDTO.LoginResult.class))),
 			@ApiResponse(responseCode = "MEMBER4004", description = "존재하지 않는 메일입니다"),
 			@ApiResponse(responseCode = "MEMBER4007", description = "비밀번호가 일치하지 않습니다")


### PR DESCRIPTION
## 💡 관련 이슈

- #59 

## 📢 작업 내용

- **일별 활동요약 목록 조회 API 구현**
  - 최신순으로 최대 3개 조회
  - Description만 조회

## 🗨️ 리뷰 요구사항(선택)

- 