### PR TITLE
[FEAT] 일별 일기 조회 API 구현

### DIFF
--- a/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
@@ -10,6 +10,8 @@ public enum DiaryErrorStatus implements ErrorReason {
 
     FUTURE_TIME(HttpStatus.BAD_REQUEST, "DIARY4001", "미래의 연/월입니다."),
     INVALID_MONTH(HttpStatus.BAD_REQUEST, "DIARY4002", "월은 1과 12 사이의 숫자이어야 합니다."),
+    INVALID_DAY(HttpStatus.BAD_REQUEST, "DIARY4003", "해당 월에 유효한 날짜가 아닙니다"),
+    NOT_WRITE_DIARY(HttpStatus.BAD_REQUEST, "DIARY4004", "해당 날짜에 작성한 일기가 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
+++ b/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
@@ -30,7 +30,18 @@ public class DiaryController implements DiaryControllerDocs {
                                                                                                  @RequestParam int year,
                                                                                                  @RequestParam int month,
                                                                                                  @RequestParam Long profileId){
-        DiaryResponseDTO.MonthDiaryListDTO result = diaryService.getMonthDiaryList(year, month, customUserDetails.getId(),profileId);
+        DiaryResponseDTO.MonthDiaryListDTO result = diaryService.getMonthDiaryList(year, month, customUserDetails.getId(), profileId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
+
+    // 일별 상세 일기 조회
+    @GetMapping("/day")
+    public ResponseEntity<CommonResponse<DiaryResponseDTO.DailyDiaryDTO>> findDailyDiary(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                            @RequestParam int year,
+                                                            @RequestParam int month,
+                                                            @RequestParam int day,
+                                                            @RequestParam Long profileId){
+        DiaryResponseDTO.DailyDiaryDTO result = diaryService.getDailyDiary(year, month, day, customUserDetails.getId(), profileId);
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
@@ -31,4 +31,24 @@ public interface DiaryControllerDocs {
                                                                                                  @RequestParam int year,
                                                                                                  @RequestParam int month,
                                                                                                  @RequestParam Long profileId);
+
+
+    @Operation(summary = "일별 일기 상세 조회API",
+            description = "특정 날짜의 일기를 상세하게 조회하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponseDTO.MonthDiaryListDTO.class))),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다."),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "DIARY4001", description = "미래의 연/월입니다."),
+                    @ApiResponse(responseCode = "DIARY4002", description = "월은 1과 12 사이의 숫자이어야 합니다."),
+                    @ApiResponse(responseCode = "DIARY4003", description = "해당 월에 유효한 날짜가 아닙니다"),
+                    @ApiResponse(responseCode = "DIARY4004", description = "해당 날짜에 작성한 일기가 없습니다.")
+
+            })
+    ResponseEntity<CommonResponse<DiaryResponseDTO.DailyDiaryDTO>> findDailyDiary(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                                  @RequestParam int year,
+                                                                                  @RequestParam int month,
+                                                                                  @RequestParam int day,
+                                                                                  @RequestParam Long profileId);
 }

--- a/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
+++ b/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
@@ -21,4 +21,14 @@ public class DiaryConverter {
                 .diaries(result)
                 .build();
     }
+
+    public static DiaryResponseDTO.DailyDiaryDTO toDailyDiaryDTO(Long profileId, Diary diary) {
+        return DiaryResponseDTO.DailyDiaryDTO.builder()
+                .profileId(profileId)
+                .diaryImage(diary.getDiaryImage())
+                .keyword(diary.getKeyword())
+                .summary(diary.getSummary())
+                .emotion(diary.getEmotion())
+                .build();
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/domain/Diary.java
+++ b/src/main/java/com/greeni/api/diaries/domain/Diary.java
@@ -1,5 +1,6 @@
 package com.greeni.api.diaries.domain;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,6 +54,9 @@ public class Diary extends BaseEntity {
 
 	@Column(nullable = false)
 	private String keyword;
+
+	@Column(nullable = false)
+	private LocalDate diaryDate;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "profile_id")

--- a/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
@@ -27,4 +27,16 @@ public class DiaryResponseDTO {
         Emotion emotion;
         int day;
     }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class DailyDiaryDTO{
+        Long profileId;
+        String diaryImage;
+        String summary;
+        Emotion emotion;
+        String keyword;
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
+++ b/src/main/java/com/greeni/api/diaries/repository/DiaryRepository.java
@@ -3,8 +3,10 @@ package com.greeni.api.diaries.repository;
 import com.greeni.api.diaries.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
@@ -12,4 +14,5 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByProfileIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(Long profileId, LocalDateTime start, LocalDateTime end);
 
+    Optional<Diary> findByProfileIdAndDiaryDate(Long profileId, LocalDate today);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -5,4 +5,6 @@ import com.greeni.api.diaries.dto.DiaryResponseDTO;
 public interface DiaryService {
 
     DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId);
+
+    DiaryResponseDTO.DailyDiaryDTO getDailyDiary(int year, int month, int day, Long id, Long profileId);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -65,4 +65,43 @@ public class DiaryServiceImpl implements DiaryService {
         return DiaryConverter.toMonthDiaryListDTO(profileId, diaryList);
     }
 
+    @Override
+    @Transactional(readOnly=true)
+    public DiaryResponseDTO.DailyDiaryDTO getDailyDiary(int year, int month, int day, Long memberId, Long profileId){
+
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
+
+        // member의 profile인지 검증
+        if (!profile.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
+
+        // 월 검증
+        if(month < 1 || month > 12){
+            throw new GeneralException(DiaryErrorStatus.INVALID_MONTH);
+        }
+
+        // 날짜 검증
+        YearMonth requestYm = YearMonth.of(year, month);
+        int lastDay = requestYm.lengthOfMonth();
+        if(day < 1 || day > lastDay){
+            throw new GeneralException(DiaryErrorStatus.INVALID_DAY);
+        }
+
+        // 미래 날짜 검증
+        LocalDate requestDate = LocalDate.of(year, month, day);
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        if(requestDate.isAfter(today)){
+            throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
+        }
+
+        // 조회
+        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
+                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
+
+        return DiaryConverter.toDailyDiaryDTO(profileId, diary);
+    }
+
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -133,7 +133,7 @@ public class DiaryServiceImpl implements DiaryService {
         return DiaryConverter.toDailyDiaryDTO(profileId, diary);
     }
 
-    public void findProfileAndValidate(Long profileId, Long memberId){
+    public Profile findProfileAndValidate(Long profileId, Long memberId){
         // Profile 엔티티 조회
         Profile profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new GeneralException(ProfileErrorStatus.PROFILE_NOT_FOUND));
@@ -142,6 +142,7 @@ public class DiaryServiceImpl implements DiaryService {
         if (!profile.getMember().getId().equals(memberId)) {
             throw new GeneralException(ProfileErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
+        return profile;
     }
 
 }

--- a/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
@@ -16,8 +16,8 @@ public class MemberRequestDTO {
 		@NotBlank(message = "이메일은 필수 입력입니다.")
 		@Email
 		@Pattern(
-			regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
-			message = "유효한 이메일 도메인만 입력하세요."
+				regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|[a-z]+\\.kr)$",
+				message = "유효한 이메일 도메인만 입력하세요."
 		)
 		@Schema(description = "사용자가 입력한 이메일", example = "greeni4child@gmail.com")
 		private String email;
@@ -42,8 +42,8 @@ public class MemberRequestDTO {
 		@NotBlank(message = "이메일은 필수 입력입니다.")
 		@Email
 		@Pattern(
-			regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
-			message = "유효한 이메일 도메인만 입력하세요."
+				regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|[a-z]+\\.kr)$",
+				message = "유효한 이메일 도메인만 입력하세요."
 		)
 		@Schema(description = "사용자가 입력한 이메일", example = "greeni4child@gmail.com")
 		private String email;
@@ -56,8 +56,8 @@ public class MemberRequestDTO {
 		@NotBlank(message = "이메일은 필수 입력입니다.")
 		@Email
 		@Pattern(
-			regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
-			message = "유효한 이메일 도메인만 입력하세요."
+				regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|[a-z]+\\.kr)$",
+				message = "유효한 이메일 도메인만 입력하세요."
 		)
 		@Schema(description = "사용자가 입력한 이메일", example = "greeni4child@gmail.com")
 		private String email;
@@ -74,8 +74,8 @@ public class MemberRequestDTO {
 		@NotBlank(message = "이메일은 필수 입력입니다.")
 		@Email
 		@Pattern(
-			regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|co\\.kr|go\\.kr)$",
-			message = "유효한 이메일 도메인만 입력하세요."
+				regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.(com|net|org|[a-z]+\\.kr)$",
+				message = "유효한 이메일 도메인만 입력하세요."
 		)
 		@Schema(description = "사용자가 입력한 이메일", example = "greeni4child@gmail.com")
 		private String email;


### PR DESCRIPTION
## 💡 관련 이슈

- #57  

## 📢 작업 내용
- 일별 일기 조회 기능 구현
   - 연도, 월, 일을 입력받아 해당 날짜의 일기 내용을 반환하도록 구현
- 일기 관련 API의 공통 로직 리팩토링
    - 프로필 조회 및 검증 로직을 공통 메서드로 분리하여 중복 코드 제거

- 회원 이메일 도메인 허용 범위 확장
   - 회원가입/로그인 시 .com, .net, .org, .kr 도메인을 모두 허용하도록 수정
   - 기존에는 ac.kr 도메인이 허용되지 않았던 문제를 해결

## 🗨️ 리뷰 요구사항(선택)

- 