### PR TITLE
[FEAT] 일기 음성 조회 API 구현

### DIFF
--- a/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
+++ b/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
@@ -6,6 +6,7 @@ import com.greeni.api.diaries.dto.DiaryResponseDTO;
 import com.greeni.api.diaries.service.DiaryService;
 import com.greeni.api.security.jwt.userDetails.CustomUserDetails;
 import jakarta.validation.Valid;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,6 +43,16 @@ public class DiaryController implements DiaryControllerDocs {
                                                             @RequestParam int day,
                                                             @RequestParam Long profileId){
         DiaryResponseDTO.DailyDiaryDTO result = diaryService.getDailyDiary(year, month, day, customUserDetails.getId(), profileId);
+        return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
+    }
+
+    @GetMapping("/day/voice")
+    public ResponseEntity<CommonResponse<DiaryResponseDTO.DiaryVoiceListDTO>> findDailyDiaryVoice(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                 @RequestParam int year,
+                                                                 @RequestParam int month,
+                                                                 @RequestParam int day,
+                                                                 @RequestParam Long profileId){
+        DiaryResponseDTO.DiaryVoiceListDTO result = diaryService.getDiaryVoice(year, month, day, customUserDetails.getId(), profileId);
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
@@ -51,4 +51,23 @@ public interface DiaryControllerDocs {
                                                                                   @RequestParam int month,
                                                                                   @RequestParam int day,
                                                                                   @RequestParam Long profileId);
+
+    @Operation(summary = "일기 음성 조회 API",
+            description = "특정 날짜의 일기의 음성을 조회하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponseDTO.DiaryVoiceListDTO.class))),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다."),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다."),
+                    @ApiResponse(responseCode = "DIARY4001", description = "미래의 연/월입니다."),
+                    @ApiResponse(responseCode = "DIARY4002", description = "월은 1과 12 사이의 숫자이어야 합니다."),
+                    @ApiResponse(responseCode = "DIARY4003", description = "해당 월에 유효한 날짜가 아닙니다"),
+                    @ApiResponse(responseCode = "DIARY4004", description = "해당 날짜에 작성한 일기가 없습니다.")
+
+            })
+    ResponseEntity<CommonResponse<DiaryResponseDTO.DiaryVoiceListDTO>> findDailyDiaryVoice(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                                           @RequestParam int year,
+                                                                                           @RequestParam int month,
+                                                                                           @RequestParam int day,
+                                                                                           @RequestParam Long profileId);
 }

--- a/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
+++ b/src/main/java/com/greeni/api/diaries/converter/DiaryConverter.java
@@ -1,6 +1,7 @@
 package com.greeni.api.diaries.converter;
 
 import com.greeni.api.diaries.domain.Diary;
+import com.greeni.api.diaries.domain.Voice;
 import com.greeni.api.diaries.domain.enums.Emotion;
 import com.greeni.api.diaries.dto.DiaryResponseDTO;
 
@@ -58,6 +59,24 @@ public class DiaryConverter {
                 .keyword(diary.getKeyword())
                 .summary(diary.getSummary())
                 .emotion(diary.getEmotion())
+                .build();
+    }
+
+    public static DiaryResponseDTO.DiaryVoiceListDTO toDiaryVoiceListDTO(List<Voice> voiceList, Long diaryId) {
+        List<DiaryResponseDTO.DiaryVoiceDTO> list = voiceList.stream()
+                .map(DiaryConverter::toDiaryVoiceDTO)
+                .toList();
+        return DiaryResponseDTO.DiaryVoiceListDTO.builder()
+                .diaryId(diaryId)
+                .voiceList(list)
+                .build();
+    }
+
+    public static DiaryResponseDTO.DiaryVoiceDTO toDiaryVoiceDTO(Voice voice) {
+        return DiaryResponseDTO.DiaryVoiceDTO.builder()
+                .voiceUrl(voice.getVoiceUrl())
+                .voiceRole(voice.getVoiceRole())
+                .createdAt(voice.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/greeni/api/diaries/domain/Voice.java
+++ b/src/main/java/com/greeni/api/diaries/domain/Voice.java
@@ -1,5 +1,6 @@
 package com.greeni.api.diaries.domain;
 
+import com.greeni.api.common.base.BaseEntity;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -30,7 +31,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "voices")
 @DynamicUpdate
 @DynamicInsert
-public class Voice {
+public class Voice extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/greeni/api/diaries/dto/DiaryResponseDTO.java
@@ -1,11 +1,13 @@
 package com.greeni.api.diaries.dto;
 
 import com.greeni.api.diaries.domain.enums.Emotion;
+import com.greeni.api.diaries.domain.enums.VoiceRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class DiaryResponseDTO {
@@ -56,5 +58,24 @@ public class DiaryResponseDTO {
         String summary;
         Emotion emotion;
         String keyword;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class DiaryVoiceListDTO{
+        List<DiaryVoiceDTO> voiceList;
+        Long diaryId;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class DiaryVoiceDTO{
+        String voiceUrl;
+        VoiceRole voiceRole;
+        LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/greeni/api/diaries/repository/VoiceRepository.java
+++ b/src/main/java/com/greeni/api/diaries/repository/VoiceRepository.java
@@ -1,0 +1,10 @@
+package com.greeni.api.diaries.repository;
+
+import com.greeni.api.diaries.domain.Voice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VoiceRepository extends JpaRepository<Voice, Long> {
+    List<Voice> findByDiaryIdOrderByCreatedAtAsc(Long diaryId);
+}

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -13,4 +13,7 @@ public interface DiaryService {
     DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId);
 
     DiaryResponseDTO.DailyDiaryDTO getDailyDiary(int year, int month, int day, Long id, Long profileId);
+
+    DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId);
+
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -5,8 +5,10 @@ import com.greeni.api.apiPayload.status.DiaryErrorStatus;
 import com.greeni.api.apiPayload.status.ProfileErrorStatus;
 import com.greeni.api.diaries.converter.DiaryConverter;
 import com.greeni.api.diaries.domain.Diary;
+import com.greeni.api.diaries.domain.Voice;
 import com.greeni.api.diaries.dto.DiaryResponseDTO;
 import com.greeni.api.diaries.repository.DiaryRepository;
+import com.greeni.api.diaries.repository.VoiceRepository;
 import com.greeni.api.profiles.domain.Profile;
 import com.greeni.api.profiles.repository.ProfileRepository;
 import org.springframework.stereotype.Service;
@@ -29,6 +31,7 @@ public class DiaryServiceImpl implements DiaryService {
 
     private final ProfileRepository profileRepository;
     private final DiaryRepository diaryRepository;
+    private final VoiceRepository voiceRepository;
 
     // 오늘의 일기 키워드 조회
     @Override
@@ -106,6 +109,35 @@ public class DiaryServiceImpl implements DiaryService {
 
         findProfileAndValidate(profileId, memberId);
 
+        LocalDate requestDate =  checkDateValidate(year, month, day);
+
+
+        // 조회
+        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
+                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
+
+        return DiaryConverter.toDailyDiaryDTO(profileId, diary);
+    }
+
+    @Override
+    @Transactional(readOnly=true)
+    public DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId) {
+
+        findProfileAndValidate(profileId, memberId);
+
+        LocalDate requestDate = checkDateValidate(year, month, day);
+
+        // 날짜 기준으로 일기 조회
+
+        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
+                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
+        // 음성 리스트 뽑기
+        List<Voice> voiceList = voiceRepository.findByDiaryIdOrderByCreatedAtAsc(diary.getId());
+
+        return DiaryConverter.toDiaryVoiceListDTO(voiceList, diary.getId());
+    }
+
+    public LocalDate checkDateValidate(int year, int month, int day){
         // 월 검증
         if(month < 1 || month > 12){
             throw new GeneralException(DiaryErrorStatus.INVALID_MONTH);
@@ -121,16 +153,10 @@ public class DiaryServiceImpl implements DiaryService {
         // 미래 날짜 검증
         LocalDate requestDate = LocalDate.of(year, month, day);
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-
         if(requestDate.isAfter(today)){
             throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
         }
-
-        // 조회
-        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
-                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
-
-        return DiaryConverter.toDailyDiaryDTO(profileId, diary);
+        return requestDate;
     }
 
     public Profile findProfileAndValidate(Long profileId, Long memberId){


### PR DESCRIPTION
## 💡 관련 이슈

- #63 

## 📢 작업 내용

- 특정 날짜에 작성한 일기의 음성을 조회하는 로직 구현
   - 저장 날짜순으로 오름차순된 음성 url 반환

## 🗨️ 리뷰 요구사항(선택)

- 