### PR TITLE
[FEAT] 일기 API - 음성 url을 받는 API 구현

### DIFF
--- a/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/DiaryErrorStatus.java
@@ -14,6 +14,7 @@ public enum DiaryErrorStatus implements ErrorReason {
     NOT_WRITE_DIARY(HttpStatus.BAD_REQUEST, "DIARY4004", "해당 날짜에 작성한 일기가 없습니다."),
     DIARY_NOT_FOUND_TODAY(HttpStatus.NOT_FOUND, "DIARY4041", "오늘 작성된 일기가 없습니다."),
     NOT_VALID_EMOTION(HttpStatus.NOT_FOUND, "DIARY4042", "올바른 감정이 아닙니다."),
+    NOT_DIARY_VOICE(HttpStatus.NOT_FOUND, "DIARY4043", "저장할 음성 url이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/apiPayload/status/TermErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/TermErrorStatus.java
@@ -1,0 +1,16 @@
+package com.greeni.api.apiPayload.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum TermErrorStatus implements ErrorReason {
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하는 이용약관이 아닙니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/greeni/api/apiPayload/status/TermErrorStatus.java
+++ b/src/main/java/com/greeni/api/apiPayload/status/TermErrorStatus.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum TermErrorStatus implements ErrorReason {
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하는 이용약관이 아닙니다"),
+    MISSING_NECESSARY_TERM(HttpStatus.NOT_FOUND, "TERM4002", "필수 동의 항목을 동의하지 않으셨습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
+++ b/src/main/java/com/greeni/api/diaries/controller/DiaryController.java
@@ -62,4 +62,11 @@ public class DiaryController implements DiaryControllerDocs {
         DiaryResponseDTO.CreateDiaryDTO result = diaryService.createDiary(customUserDetails.getId(), request);
         return new ResponseEntity<>(CommonResponse.onSuccess(result), HttpStatus.OK);
     }
+
+    @PostMapping("/voice")
+    public ResponseEntity<CommonResponse<?>> getVoice(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                      @RequestBody @Valid DiaryRequestDTO.DiaryUrlDTO request){
+        diaryService.getVoiceUrl(customUserDetails.getId(), request);
+        return new ResponseEntity<>(CommonResponse.onSuccess(null), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/greeni/api/diaries/controller/docs/DiaryControllerDocs.java
@@ -85,4 +85,15 @@ public interface DiaryControllerDocs {
             })
     ResponseEntity<CommonResponse<DiaryResponseDTO.CreateDiaryDTO>> makeDiary(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                                               @RequestBody @Valid DiaryRequestDTO.DiarySaveDTO request);
+
+    @Operation(summary = "일기 음성 URL 전달 API",
+            description = "일기 음성 URL을 전달하는 API",
+            responses = {
+                    @ApiResponse(responseCode = "COMMON200", description = "요청이 성공했습니다.",
+                            content = @Content(mediaType = "application/json")),
+                    @ApiResponse(responseCode = "PROFILE4041", description = "존재하지 않는 프로필입니다."),
+                    @ApiResponse(responseCode = "PROFILE4031", description = "해당 프로필에 접근할 권한이 없습니다.")
+            })
+    ResponseEntity<CommonResponse<?>> getVoice(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                      @RequestBody @Valid DiaryRequestDTO.DiaryUrlDTO request);
 }

--- a/src/main/java/com/greeni/api/diaries/converter/VoiceConverter.java
+++ b/src/main/java/com/greeni/api/diaries/converter/VoiceConverter.java
@@ -9,14 +9,20 @@ import java.util.List;
 
 public class VoiceConverter {
 
-    public static List<Voice> toVoice(List<DiaryRequestDTO.VoiceDTO> voices, Long sessionId, Diary diary){
+    public static List<Voice> toVoice(List<String> voices, Long sessionId, Diary diary){
         return voices.stream()
-                .map(voiceDto -> Voice.builder()
-                        .voiceUrl(voiceDto.getUrl())
-                        .voiceRole(voiceDto.getRole().equals("CHILD") ? VoiceRole.CHILD : VoiceRole.GREENI)
-                        .sessionId(sessionId)
-                        .diary(diary)
-                        .build())
+                .map(v -> {
+                    String[] parts = v.split("\\|");
+                    String role = parts[0];
+                    String url = parts[1];
+
+                    return Voice.builder()
+                            .voiceUrl(url)
+                            .voiceRole(role.equals("CHILD") ? VoiceRole.CHILD : VoiceRole.GREENI)
+                            .sessionId(sessionId)
+                            .diary(diary)
+                            .build();
+                })
                 .toList();
     }
 

--- a/src/main/java/com/greeni/api/diaries/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/greeni/api/diaries/dto/DiaryRequestDTO.java
@@ -28,16 +28,13 @@ public class DiaryRequestDTO {
         String summary;
 
         @NotNull
-        List<VoiceDTO> voiceList;
-
-        @NotNull
         String emotion;
 
         @NotNull
         String keyword;
     }
 
-    @Builder
+    /*@Builder
     @AllArgsConstructor
     @Getter
     @NoArgsConstructor
@@ -47,10 +44,10 @@ public class DiaryRequestDTO {
 
         @NotNull
         String role;
-    }
+    }*/
 
     public record DiaryUrlDTO(
         @NotNull
-        String url, @NotNull Long profileId){}
+        String url, @NotNull Long profileId, @NotNull String role){}
 
 }

--- a/src/main/java/com/greeni/api/diaries/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/greeni/api/diaries/dto/DiaryRequestDTO.java
@@ -49,4 +49,8 @@ public class DiaryRequestDTO {
         String role;
     }
 
+    public record DiaryUrlDTO(
+        @NotNull
+        String url, @NotNull Long profileId){}
+
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -3,6 +3,7 @@ package com.greeni.api.diaries.service;
 import com.greeni.api.diaries.dto.DiaryRequestDTO;
 import com.greeni.api.diaries.dto.DiaryResponseDTO;
 import com.greeni.api.profiles.domain.Profile;
+import jakarta.validation.Valid;
 
 public interface DiaryService {
 
@@ -19,4 +20,6 @@ public interface DiaryService {
     DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId);
 
     DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request);
+
+    void getVoiceUrl(Long id, DiaryRequestDTO.@Valid DiaryUrlDTO request);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -21,5 +21,5 @@ public interface DiaryService {
 
     DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request);
 
-    void getVoiceUrl(Long id, DiaryRequestDTO.@Valid DiaryUrlDTO request);
+    void getVoiceUrl(Long id, DiaryRequestDTO.DiaryUrlDTO request);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.greeni.api.activities.converter.ActivityConverter;
 import com.greeni.api.activities.domain.Activity;
@@ -15,6 +16,10 @@ import com.greeni.api.badges.service.BadgeService;
 import com.greeni.api.diaries.converter.VoiceConverter;
 import com.greeni.api.diaries.dto.DiaryRequestDTO;
 import com.greeni.api.profiles.service.ProfileQueryService;
+import jakarta.validation.Valid;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +51,7 @@ public class DiaryServiceImpl implements DiaryService {
     private final VoiceRepository voiceRepository;
 	private final ActivityService activityService;
 	private final BadgeService badgeService;
+	private final RedisTemplate<String, Object> redistemplate;
 
 	// 오늘의 일기 키워드 조회
 	@Override
@@ -191,6 +197,20 @@ public class DiaryServiceImpl implements DiaryService {
 		badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
 
 		return DiaryConverter.toCreateDiaryDTO(diary.getId());
+	}
+
+	@Override
+	public void getVoiceUrl(Long memberId, DiaryRequestDTO.DiaryUrlDTO request) {
+		// 프로필 존재 확인
+		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
+
+		// redis에 일기 url 저장하기
+		ListOperations<String, Object> ops = redistemplate.opsForList();
+		String key = "diary:voice:" + memberId + ":" + request.profileId();
+		ops.rightPush(key, request.url());
+		if(redistemplate.getExpire(key) == -1) {
+			redistemplate.expire(key, 1, TimeUnit.HOURS);
+		}
 	}
 
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -51,7 +51,7 @@ public class DiaryServiceImpl implements DiaryService {
     private final VoiceRepository voiceRepository;
 	private final ActivityService activityService;
 	private final BadgeService badgeService;
-	private final RedisTemplate<String, Object> redistemplate;
+	private final RedisTemplate<String, String> redistemplate;
 
 	// 오늘의 일기 키워드 조회
 	@Override
@@ -185,7 +185,13 @@ public class DiaryServiceImpl implements DiaryService {
 
 		Diary diary = DiaryConverter.toDiary(request, profile);
 		diaryRepository.save(diary);
-		List<Voice> voiceList = VoiceConverter.toVoice(request.getVoiceList(), request.getSessionId(), diary);
+		ListOperations<String, String> ops = redistemplate.opsForList();
+		String key = "diary:voice:" + memberId + ":" + request.getProfileId();
+		List<String> urls = ops.range(key, 0, -1);
+		if(urls.isEmpty()){
+			throw new GeneralException(DiaryErrorStatus.NOT_DIARY_VOICE);
+		}
+		List<Voice> voiceList = VoiceConverter.toVoice(urls, request.getSessionId(), diary);
 		voiceRepository.saveAll(voiceList);
 
 		String description = "일기 작성을 완료했습니다.";
@@ -205,9 +211,10 @@ public class DiaryServiceImpl implements DiaryService {
 		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
 
 		// redis에 일기 url 저장하기
-		ListOperations<String, Object> ops = redistemplate.opsForList();
+		ListOperations<String, String> ops = redistemplate.opsForList();
 		String key = "diary:voice:" + memberId + ":" + request.profileId();
-		ops.rightPush(key, request.url());
+		String value = request.role() + "|" + request.url();
+		ops.rightPush(key, value);
 		if(redistemplate.getExpire(key) == -1) {
 			redistemplate.expire(key, 1, TimeUnit.HOURS);
 		}

--- a/src/main/java/com/greeni/api/members/converter/MemberTermConverter.java
+++ b/src/main/java/com/greeni/api/members/converter/MemberTermConverter.java
@@ -1,0 +1,15 @@
+package com.greeni.api.members.converter;
+
+import com.greeni.api.members.domain.Member;
+import com.greeni.api.members.domain.Term;
+import com.greeni.api.members.domain.mapping.MemberTerm;
+
+public class MemberTermConverter {
+
+    public static MemberTerm toMemberTerm(Member member, Term term){
+        return MemberTerm.builder()
+                .member(member)
+                .term(term)
+                .build();
+    }
+}

--- a/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
@@ -3,6 +3,7 @@ package com.greeni.api.members.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,15 @@ public class MemberRequestDTO {
 		@NotBlank(message = "인증 코드는 필수 입력입니다.")
 		@Schema(description = "이메일로 전송된 인증번호", example = "123456")
 		private String code;
+
+		@NotNull(message = "14세 미만 법정 대리인 동의는 필수입니다")
+		private boolean guardianConsent;
+
+		@NotNull(message = "개인정보 수집 및 이용 동의는 필수입니다")
+		private boolean personalInfoConsent;
+
+		@NotNull(message = "이용 약관 동의는 필수입니다")
+		private boolean termsAgreement;
 	}
 
 	@Getter

--- a/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
+++ b/src/main/java/com/greeni/api/members/dto/MemberRequestDTO.java
@@ -1,12 +1,11 @@
 package com.greeni.api.members.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class MemberRequestDTO {
 
@@ -35,14 +34,9 @@ public class MemberRequestDTO {
 		@Schema(description = "이메일로 전송된 인증번호", example = "123456")
 		private String code;
 
-		@NotNull(message = "14세 미만 법정 대리인 동의는 필수입니다")
-		private boolean guardianConsent;
+		@NotEmpty
+		private List<Long> requiredAgreement;
 
-		@NotNull(message = "개인정보 수집 및 이용 동의는 필수입니다")
-		private boolean personalInfoConsent;
-
-		@NotNull(message = "이용 약관 동의는 필수입니다")
-		private boolean termsAgreement;
 	}
 
 	@Getter

--- a/src/main/java/com/greeni/api/members/repository/MemberTermRepository.java
+++ b/src/main/java/com/greeni/api/members/repository/MemberTermRepository.java
@@ -1,0 +1,8 @@
+package com.greeni.api.members.repository;
+
+import com.greeni.api.members.converter.MemberTermConverter;
+import com.greeni.api.members.domain.mapping.MemberTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
+}

--- a/src/main/java/com/greeni/api/members/repository/TermRepository.java
+++ b/src/main/java/com/greeni/api/members/repository/TermRepository.java
@@ -2,6 +2,11 @@ package com.greeni.api.members.repository;
 
 import com.greeni.api.members.domain.Term;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
+    @Query("SELECT t.id FROM Term t WHERE t.required = true")
+    List<Long> findRequiredTermIds();
 }

--- a/src/main/java/com/greeni/api/members/repository/TermRepository.java
+++ b/src/main/java/com/greeni/api/members/repository/TermRepository.java
@@ -1,0 +1,7 @@
+package com.greeni.api.members.repository;
+
+import com.greeni.api.members.domain.Term;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/com/greeni/api/members/service/MemberServiceImpl.java
+++ b/src/main/java/com/greeni/api/members/service/MemberServiceImpl.java
@@ -1,8 +1,15 @@
 package com.greeni.api.members.service;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import com.greeni.api.apiPayload.status.TermErrorStatus;
+import com.greeni.api.members.converter.MemberTermConverter;
+import com.greeni.api.members.domain.Term;
+import com.greeni.api.members.domain.mapping.MemberTerm;
+import com.greeni.api.members.repository.MemberTermRepository;
+import com.greeni.api.members.repository.TermRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -34,6 +41,8 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberServiceImpl implements MemberService {
 
 	private final MemberRepository memberRepository;
+	private final TermRepository termRepository;
+	private final MemberTermRepository memberTermRepository;
 	private final JavaMailSender javaMailSender;
 	private final RedisTemplate<String, Object> redistemplate;
 	private final PasswordEncoder passwordEncoder;
@@ -47,18 +56,31 @@ public class MemberServiceImpl implements MemberService {
 
 		// 이메일 인증 완료 여부 확인
 		checkEmailCode(request.getEmail(), request.getCode());
-		//        ValueOperations<String, Object> ops = redistemplate.opsForValue();
-		//        String codeNum = (String) ops.get("EmailCode"+request.getEmail());
-		//        if(codeNum == null){
-		//            throw new GeneralException(ErrorStatus.EXPIRED_CODE);
-		//        }
-		//        if(!codeNum.equals(request.getCode())){
-		//            throw new GeneralException(ErrorStatus.WRONG_CODE);
-		//        }
 
 		Member member = MemberConverter.toMember(request);
 		member.encodePassword(passwordEncoder.encode(member.getPassword()));
 		memberRepository.save(member);
+
+		if(request.isGuardianConsent()){
+			Term guardianConsent = termRepository.findById(1L)
+					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
+			MemberTerm guardianConsentAndMember = MemberTermConverter.toMemberTerm(member, guardianConsent);
+			memberTermRepository.save(guardianConsentAndMember);
+		}
+
+		if(request.isPersonalInfoConsent()){
+			Term personalInfoConsent = termRepository.findById(2L)
+					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
+			MemberTerm personalInfoConsentAndMember = MemberTermConverter.toMemberTerm(member, personalInfoConsent);
+			memberTermRepository.save(personalInfoConsentAndMember);
+		}
+
+		if(request.isTermsAgreement()){
+			Term termsAgreement = termRepository.findById(3L)
+					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
+			MemberTerm termsAgreementAndMember = MemberTermConverter.toMemberTerm(member, termsAgreement);
+			memberTermRepository.save(termsAgreementAndMember);
+		}
 
 		return MemberConverter.toMemberResultDTO(member);
 	}

--- a/src/main/java/com/greeni/api/members/service/MemberServiceImpl.java
+++ b/src/main/java/com/greeni/api/members/service/MemberServiceImpl.java
@@ -1,7 +1,10 @@
 package com.greeni.api.members.service;
 
 import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.greeni.api.apiPayload.status.TermErrorStatus;
@@ -61,26 +64,26 @@ public class MemberServiceImpl implements MemberService {
 		member.encodePassword(passwordEncoder.encode(member.getPassword()));
 		memberRepository.save(member);
 
-		if(request.isGuardianConsent()){
-			Term guardianConsent = termRepository.findById(1L)
-					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
-			MemberTerm guardianConsentAndMember = MemberTermConverter.toMemberTerm(member, guardianConsent);
-			memberTermRepository.save(guardianConsentAndMember);
+		// 필수 약관 동의 여부 확인
+		List<Long> requiredTrueIds = termRepository.findRequiredTermIds();
+		Set<Long> requestRequiredIds = new HashSet<>(request.getRequiredAgreement());
+		if(!requestRequiredIds.containsAll(requiredTrueIds)){
+			throw new GeneralException(TermErrorStatus.MISSING_NECESSARY_TERM);
 		}
 
-		if(request.isPersonalInfoConsent()){
-			Term personalInfoConsent = termRepository.findById(2L)
+		for(Long requiredId : request.getRequiredAgreement()){
+			Term termsAgreement = termRepository.findById(requiredId)
 					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
-			MemberTerm personalInfoConsentAndMember = MemberTermConverter.toMemberTerm(member, personalInfoConsent);
-			memberTermRepository.save(personalInfoConsentAndMember);
+			MemberTerm memberTerm = MemberTermConverter.toMemberTerm(member, termsAgreement);
+			memberTermRepository.save(memberTerm);
 		}
 
-		if(request.isTermsAgreement()){
-			Term termsAgreement = termRepository.findById(3L)
-					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
-			MemberTerm termsAgreementAndMember = MemberTermConverter.toMemberTerm(member, termsAgreement);
-			memberTermRepository.save(termsAgreementAndMember);
-		}
+//		if(request.isTermsAgreement()){
+//			Term termsAgreement = termRepository.findById(3L)
+//					.orElseThrow(() -> new GeneralException(TermErrorStatus.TERM_NOT_FOUND));
+//			MemberTerm termsAgreementAndMember = MemberTermConverter.toMemberTerm(member, termsAgreement);
+//			memberTermRepository.save(termsAgreementAndMember);
+//		}
 
 		return MemberConverter.toMemberResultDTO(member);
 	}


### PR DESCRIPTION
## 💡 관련 이슈

- #74 

## 📢 작업 내용

- 음성 url을 redis에 저장해두도록 구현(TTL : 1시간)
- 일기 저장시, 음성 url을 외부에서 받아오는게 아닌, redis에 저장해둔 음성 리스트를 사용하도록 수정
- 이용 약관 동의 필드 추가

## 🗨️ 리뷰 요구사항(선택)

- 