### PR TITLE
[FEAT] AI 서버 에러 응답 시 재요청하는 로직 추가

### DIFF
--- a/src/main/java/com/greeni/api/ai/service/AIService.java
+++ b/src/main/java/com/greeni/api/ai/service/AIService.java
@@ -1,5 +1,25 @@
 package com.greeni.api.ai.service;
 
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
 import com.greeni.api.activities.converter.ActivityConverter;
 import com.greeni.api.activities.domain.Activity;
 import com.greeni.api.activities.domain.enums.ActivityType;
@@ -20,28 +40,13 @@ import com.greeni.api.diaries.domain.enums.VoiceRole;
 import com.greeni.api.diaries.repository.DiaryRepository;
 import com.greeni.api.profiles.domain.Profile;
 import com.greeni.api.profiles.service.ProfileQueryService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.MediaType;
-import org.springframework.http.client.MultipartBodyBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import reactor.util.retry.Retry;
 
 @Slf4j
 @Service
@@ -49,358 +54,384 @@ import java.util.concurrent.TimeUnit;
 @Transactional(readOnly = true)
 public class AIService {
 
-    private final WebClient aiWebClient;
-    private final DiaryRepository diaryRepository;
-    private final RedisTemplate<String, String> redistemplate;
-    private final ProfileQueryService profileQueryService;
-    private final ActivityService activityService;
-    private final ActivityRepository activityRepository;
-    private final BadgeService badgeService;
+	private final WebClient aiWebClient;
+	private final DiaryRepository diaryRepository;
+	private final RedisTemplate<String, String> redistemplate;
+	private final ProfileQueryService profileQueryService;
+	private final ActivityService activityService;
+	private final ActivityRepository activityRepository;
+	private final BadgeService badgeService;
 
-    public Mono<AIResponseDTO.FiveQuestionsHintResponse> fiveQuestionsHint(AIRequestDTO.FiveQuestionsHint request) {
+	public Mono<AIResponseDTO.FiveQuestionsHintResponse> fiveQuestionsHint(AIRequestDTO.FiveQuestionsHint request) {
 
-        Purpose purpose = Purpose.FIVEQ;
+		Purpose purpose = Purpose.FIVEQ;
 
-        return aiWebClient.post()
-                .uri("/game/fiveq/hint")
-                .bodyValue(request)
-                .retrieve()
-                .bodyToMono(AIResponseDTO.FiveQuestionsHintText.class)
+		return aiWebClient.post()
+			.uri("/game/fiveq/hint")
+			.bodyValue(request)
+			.retrieve()
+			.bodyToMono(AIResponseDTO.FiveQuestionsHintText.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.flatMap(context -> {
+				List<String> hintList = context.hints();
+				if (hintList == null) {
+					hintList = Collections.emptyList();
+				}
 
-                .flatMap(context -> {
-                    List<String> hintList = context.hints();
-                    if (hintList == null) {
-                        hintList = Collections.emptyList();
-                    }
+				if (hintList.isEmpty()) {
+					return Mono.just(AIResponseDTO.FiveQuestionsHintResponse.builder()
+						.hints(Collections.emptyList())
+						.build());
+				}
+				return Flux.fromIterable(hintList)
+					.concatMap(hintText -> {
+						AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
+							purpose, hintText, null, null, null
+						);
+						return aiWebClient.post()
+							.uri("/tts/speak")
+							.bodyValue(ttsRequest)
+							.retrieve()
+							.bodyToMono(AIResponseDTO.TTSResponse.class)
+							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+								.filter(throwable -> throwable instanceof WebClientRequestException))
+							.doOnError(WebClientResponseException.class, e -> {
+								log.error("TTS 에러: {}", e.getResponseBodyAsString());
+							})
+							.map(base64Audio -> new AIResponseDTO.TextVoiceData(hintText, base64Audio.audioContent()));
+					})
+					.collectList()
+					.map(hintDataList -> AIResponseDTO.FiveQuestionsHintResponse.builder()
+						.hints(hintDataList)
+						.build()
+					);
+			});
+	}
 
-                    if (hintList.isEmpty()) {
-                        return Mono.just(AIResponseDTO.FiveQuestionsHintResponse.builder()
-                                .hints(Collections.emptyList())
-                                .build());
-                    }
-                    return Flux.fromIterable(hintList)
-                            .concatMap(hintText -> {
-                                AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
-                                        purpose, hintText, null, null, null
-                                );
-                                return aiWebClient.post()
-                                        .uri("/tts/speak")
-                                        .bodyValue(ttsRequest)
-                                        .retrieve()
-                                        .bodyToMono(AIResponseDTO.TTSResponse.class)
-                                        .doOnError(WebClientResponseException.class, e -> {
-                                            log.error("TTS 에러: {}", e.getResponseBodyAsString());
-                                        })
-                                        .map(base64Audio -> new AIResponseDTO.TextVoiceData(hintText, base64Audio.audioContent()));
-                            })
-                            .collectList()
-                            .map(hintDataList -> AIResponseDTO.FiveQuestionsHintResponse.builder()
-                                    .hints(hintDataList)
-                                    .build()
-                            );
-                });
-    }
+	public Mono<AIResponseDTO.FiveQuestionsCheckResponse> fiveQuestionsCheck(AIRequestDTO.FiveQuestionsCheck request) {
 
-    public Mono<AIResponseDTO.FiveQuestionsCheckResponse> fiveQuestionsCheck(AIRequestDTO.FiveQuestionsCheck request) {
+		Purpose purpose = Purpose.FIVEQ;
 
-        Purpose purpose = Purpose.FIVEQ;
+		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
 
-        MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
+		return aiWebClient.post()
+			.uri("/stt/transcribe")
+			.body(BodyInserters.fromMultipartData(builder.build()))
+			.retrieve()
+			.bodyToMono(AIResponseDTO.STTResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.doOnError(WebClientResponseException.class, e -> {
+				log.error("STT 에러: {}", e.getResponseBodyAsString());
+			})
+			.flatMap(sttRes -> {
+				String recognizedText = sttRes.text();
+				log.debug("아이가 한 말: {}", recognizedText);
 
-        return aiWebClient.post()
-                .uri("/stt/transcribe")
-                .body(BodyInserters.fromMultipartData(builder.build()))
-                .retrieve()
-                .bodyToMono(AIResponseDTO.STTResponse.class)
-                .doOnError(WebClientResponseException.class, e -> {
-                    log.error("STT 에러: {}", e.getResponseBodyAsString());
-                })
-                .flatMap(sttRes -> {
-                    String recognizedText = sttRes.text();
-                    log.debug("아이가 한 말: {}", recognizedText);
+				AIRequestDTO.FiveQuestionsCheckInner checkInnerReq = new AIRequestDTO.FiveQuestionsCheckInner(
+					recognizedText,
+					request.answer()
+				);
 
-                    AIRequestDTO.FiveQuestionsCheckInner checkInnerReq = new AIRequestDTO.FiveQuestionsCheckInner(
-                            recognizedText,
-                            request.answer()
-                    );
+				return aiWebClient.post()
+					.uri("/game/fiveq/check")
+					.bodyValue(checkInnerReq)
+					.retrieve()
+					.bodyToMono(AIResponseDTO.FiveQuestionsCheckAnswer.class)
+					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+						.filter(throwable -> throwable instanceof WebClientRequestException))
+					.doOnError(e -> log.error("FiveQ Check 에러: {}", e.getMessage()))
+					.map(checkAns -> {
+						Boolean correct = checkAns.correct();
+						return AIResponseDTO.FiveQuestionsCheckResponse.of(
+							correct, null
+						);
+					});
+			});
+	}
 
-                    return aiWebClient.post()
-                            .uri("/game/fiveq/check")
-                            .bodyValue(checkInnerReq)
-                            .retrieve()
-                            .bodyToMono(AIResponseDTO.FiveQuestionsCheckAnswer.class)
-                            .doOnError(e -> log.error("FiveQ Check 에러: {}", e.getMessage()))
-                            .map(checkAns -> {
-                                Boolean correct = checkAns.correct();
-                                return AIResponseDTO.FiveQuestionsCheckResponse.of(
-                                        correct, null
-                                );
-                            });
-                });
-    }
+	public Mono<AIResponseDTO.RolePlayingResponse> rolePlaying(AIRequestDTO.RolePlaying request) {
 
-    public Mono<AIResponseDTO.RolePlayingResponse> rolePlaying(AIRequestDTO.RolePlaying request) {
+		Purpose purpose = Purpose.ROLEPLAY;
+		RolePlayingType type = RolePlayingType.valueOf(request.role().toUpperCase());
 
-        Purpose purpose = Purpose.ROLEPLAY;
-        RolePlayingType type = RolePlayingType.valueOf(request.role().toUpperCase());
+		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
 
-        MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
+		return aiWebClient.post()
+			.uri("/stt/transcribe")
+			.body(BodyInserters.fromMultipartData(builder.build()))
+			.retrieve()
+			.bodyToMono(AIResponseDTO.STTResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.doOnError(WebClientResponseException.class, e -> {
+				log.error("STT 에러: {}", e.getResponseBodyAsString());
+			})
+			.flatMap(sttRes -> {
+				String recognizedText = sttRes.text();
+				log.debug("아이가 한 말: {}", recognizedText);
 
-        return aiWebClient.post()
-                .uri("/stt/transcribe")
-                .body(BodyInserters.fromMultipartData(builder.build()))
-                .retrieve()
-                .bodyToMono(AIResponseDTO.STTResponse.class)
-                .doOnError(WebClientResponseException.class, e -> {
-                    log.error("STT 에러: {}", e.getResponseBodyAsString());
-                })
-                .flatMap(sttRes -> {
-                    String recognizedText = sttRes.text();
-                    log.debug("아이가 한 말: {}", recognizedText);
+				AIRequestDTO.RolePlayingInner rolePlayingReq = new AIRequestDTO.RolePlayingInner(
+					request.sessionId(), type, recognizedText, null, null, null
+				);
 
-                    AIRequestDTO.RolePlayingInner rolePlayingReq = new AIRequestDTO.RolePlayingInner(
-                            request.sessionId(), type, recognizedText, null, null, null
-                    );
+				return aiWebClient.post()
+					.uri("/chat/roleplay")
+					.bodyValue(rolePlayingReq)
+					.retrieve()
+					.bodyToMono(AIResponseDTO.RolePlayingInnerResponse.class)
+					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+						.filter(throwable -> throwable instanceof WebClientRequestException))
+					.doOnError(e -> log.error("RolePlaying 에러: {}", e.getMessage()))
+					.flatMap(roleRes -> {
+						AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
+							purpose, roleRes.reply(), null, null, null
+						);
+						return aiWebClient.post()
+							.uri("/tts/speak")
+							.bodyValue(ttsRequest)
+							.retrieve()
+							.bodyToMono(AIResponseDTO.TTSResponse.class)
+							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+								.filter(throwable -> throwable instanceof WebClientRequestException))
+							.doOnError(WebClientResponseException.class, e -> {
+								log.error("TTS 에러: {}", e.getResponseBodyAsString());
+							})
+							.map(base64Audio -> AIResponseDTO.RolePlayingResponse.of(
+								request.sessionId(), base64Audio.audioContent(), roleRes.reply(), roleRes.turn()
+							));
+					});
+			});
+	}
 
-                    return aiWebClient.post()
-                            .uri("/chat/roleplay")
-                            .bodyValue(rolePlayingReq)
-                            .retrieve()
-                            .bodyToMono(AIResponseDTO.RolePlayingInnerResponse.class)
-                            .doOnError(e -> log.error("RolePlaying 에러: {}", e.getMessage()))
-                            .flatMap(roleRes -> {
-                                AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
-                                        purpose, roleRes.reply(), null, null, null
-                                );
-                                return aiWebClient.post()
-                                        .uri("/tts/speak")
-                                        .bodyValue(ttsRequest)
-                                        .retrieve()
-                                        .bodyToMono(AIResponseDTO.TTSResponse.class)
-                                        .doOnError(WebClientResponseException.class, e -> {
-                                            log.error("TTS 에러: {}", e.getResponseBodyAsString());
-                                        })
-                                        .map(base64Audio -> AIResponseDTO.RolePlayingResponse.of(
-                                                request.sessionId(), base64Audio.audioContent(), roleRes.reply(), roleRes.turn()
-                                        ));
-                            });
-                });
-    }
+	public Mono<AIResponseDTO.RolePlayingEndResponse> rolePlayingClose(AIRequestDTO.RolePlayingEnd request) {
+		return aiWebClient.post()
+			.uri("/chat/roleplay/close")
+			.bodyValue(request)
+			.retrieve()
+			.bodyToMono(AIResponseDTO.RolePlayingEndResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.map(result -> AIResponseDTO.RolePlayingEndResponse.of(request.sessionId()));
+	}
 
-    public Mono<AIResponseDTO.RolePlayingEndResponse> rolePlayingClose(AIRequestDTO.RolePlayingEnd request) {
-        return aiWebClient.post()
-                .uri("/chat/roleplay/close")
-                .bodyValue(request)
-                .retrieve()
-                .bodyToMono(AIResponseDTO.RolePlayingEndResponse.class)
-                .map(result -> AIResponseDTO.RolePlayingEndResponse.of(request.sessionId()));
-    }
+	private MultipartBodyBuilder buildVoiceMultipart(MultipartFile voice, Purpose purpose, String sessionId) {
 
-    private MultipartBodyBuilder buildVoiceMultipart(MultipartFile voice, Purpose purpose, String sessionId) {
+		MultipartBodyBuilder builder = new MultipartBodyBuilder();
 
-        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+		try {
+			byte[] voiceBytes = voice.getBytes();
+			String originalFileName = voice.getOriginalFilename();
 
-        try {
-            byte[] voiceBytes = voice.getBytes();
-            String originalFileName = voice.getOriginalFilename();
+			if (originalFileName == null || originalFileName.isEmpty()) {
+				originalFileName = "audio.mp4";
+			}
 
-            if (originalFileName == null || originalFileName.isEmpty()) {
-                originalFileName = "audio.mp4";
-            }
+			builder.part("voice", new ByteArrayResource(voiceBytes))
+				.filename(originalFileName)
+				.contentType(MediaType.parseMediaType("audio/mp4"));
+		} catch (IOException e) {
+			throw new GeneralException(CommonErrorStatus.VOICE_PARSING_ERROR);
+		}
+		builder.part("purpose", purpose.getName());
+		if (sessionId != null) {
+			builder.part("session_id", sessionId);
+		}
 
-            builder.part("voice", new ByteArrayResource(voiceBytes))
-                    .filename(originalFileName)
-                    .contentType(MediaType.parseMediaType("audio/mp4"));
-        } catch (IOException e) {
-            throw new GeneralException(CommonErrorStatus.VOICE_PARSING_ERROR);
-        }
-        builder.part("purpose", purpose.getName());
-        if (sessionId != null) {
-            builder.part("session_id", sessionId);
-        }
+		return builder;
+	}
 
-        return builder;
-    }
+	// 일기 대화 요청 로직
+	public Mono<AIResponseDTO.DiaryResponse> diary(AIRequestDTO.DiaryRequest request, Long memberId) {
+		// 프론트에서 받은 s3 redis에 저장하는 로직
+		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
 
-    // 일기 대화 요청 로직
-    public Mono<AIResponseDTO.DiaryResponse> diary(AIRequestDTO.DiaryRequest request, Long memberId) {
-        // 프론트에서 받은 s3 redis에 저장하는 로직
-        Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
+		if (diaryRepository.findByProfileIdAndDiaryDate(profile.getId(), LocalDate.now()).isPresent()) {
+			throw new GeneralException(DiaryErrorStatus.EXIST_TODAY_DIARY);
+		}
 
-        if(diaryRepository.findByProfileIdAndDiaryDate(profile.getId(), LocalDate.now()).isPresent()){
-            throw new GeneralException(DiaryErrorStatus.EXIST_TODAY_DIARY);
-        }
+		ListOperations<String, String> ops = redistemplate.opsForList();
+		String key = "diary:voice:" + memberId + ":" + request.profileId();
+		String value = "CHILD|" + request.voiceUrl();
+		ops.rightPush(key, value);
+		if (redistemplate.getExpire(key) == -1) {
+			redistemplate.expire(key, 1, TimeUnit.HOURS);
+		}
 
-        ListOperations<String, String> ops = redistemplate.opsForList();
-        String key = "diary:voice:" + memberId + ":" + request.profileId();
-        String value = "CHILD|" + request.voiceUrl();
-        ops.rightPush(key, value);
-        if(redistemplate.getExpire(key) == -1) {
-            redistemplate.expire(key, 1, TimeUnit.HOURS);
-        }
+		// 일기 요청 대화 로직
+		Purpose purpose = Purpose.DIARY;
 
-        // 일기 요청 대화 로직
-        Purpose purpose = Purpose.DIARY;
+		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
 
-        MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
+		return aiWebClient.post()
+			.uri("/stt/transcribe")
+			.body(BodyInserters.fromMultipartData(builder.build()))
+			.retrieve()
+			.bodyToMono(AIResponseDTO.STTResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.doOnError(WebClientResponseException.class, e -> {
+				log.error("STT 에러: {}", e.getResponseBodyAsString());
+			})
+			.flatMap(sttRes -> {
+				String recognizedText = sttRes.text();
+				log.debug("아이가 한 말: {}", recognizedText);
 
-        return aiWebClient.post()
-                .uri("/stt/transcribe")
-                .body(BodyInserters.fromMultipartData(builder.build()))
-                .retrieve()
-                .bodyToMono(AIResponseDTO.STTResponse.class)
-                .doOnError(WebClientResponseException.class, e -> {
-                    log.error("STT 에러: {}", e.getResponseBodyAsString());
-                })
-                .flatMap(sttRes -> {
-                    String recognizedText = sttRes.text();
-                    log.debug("아이가 한 말: {}", recognizedText);
+				AIRequestDTO.DiaryInner diaryReq = new AIRequestDTO.DiaryInner(
+					request.session_id(), recognizedText
+				);
 
-                    AIRequestDTO.DiaryInner diaryReq = new AIRequestDTO.DiaryInner(
-                            request.session_id(), recognizedText
-                    );
+				return aiWebClient.post()
+					.uri("/diary/chat")
+					.bodyValue(diaryReq)
+					.retrieve()
+					.bodyToMono(AIResponseDTO.DiaryInnerResponse.class)
+					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+						.filter(throwable -> throwable instanceof WebClientRequestException))
+					.doOnError(e -> log.error("Diary 에러: {}", e.getMessage()))
+					.flatMap(diaryInnerResponse -> {
+						AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
+							purpose, diaryInnerResponse.reply(), null, null, null
+						);
+						return aiWebClient.post()
+							.uri("/tts/speak")
+							.bodyValue(ttsRequest)
+							.retrieve()
+							.bodyToMono(AIResponseDTO.TTSResponse.class)
+							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+								.filter(throwable -> throwable instanceof WebClientRequestException))
+							.doOnError(WebClientResponseException.class, e ->
+								log.error("TTS 에러: {}", e.getResponseBodyAsString())
+							)
+							// ai서버로부터 온 s3 url 저장 로직
+							.map(ttsRes -> {
+								if (ttsRes.audioUrl() != null) {
+									String aiValue = "GREENI|" + ttsRes.audioUrl();
+									List<String> existingList = ops.range(key, 0, -1);
 
-                    return aiWebClient.post()
-                            .uri("/diary/chat")
-                            .bodyValue(diaryReq)
-                            .retrieve()
-                            .bodyToMono(AIResponseDTO.DiaryInnerResponse.class)
-                            .doOnError(e -> log.error("Diary 에러: {}", e.getMessage()))
-                            .flatMap(diaryInnerResponse -> {
-                                AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
-                                        purpose, diaryInnerResponse.reply(), null, null, null
-                                );
-                                return aiWebClient.post()
-                                        .uri("/tts/speak")
-                                        .bodyValue(ttsRequest)
-                                        .retrieve()
-                                        .bodyToMono(AIResponseDTO.TTSResponse.class)
-                                        .doOnError(WebClientResponseException.class, e ->
-                                                log.error("TTS 에러: {}", e.getResponseBodyAsString())
-                                        )
-                                        // ai서버로부터 온 s3 url 저장 로직
-                                        .map(ttsRes -> {
-                                            if (ttsRes.audioUrl() != null) {
-                                                String aiValue = "GREENI|" + ttsRes.audioUrl();
-                                                List<String> existingList = ops.range(key, 0, -1);
+									if (existingList == null || !existingList.contains(aiValue)) {
+										ops.rightPush(key, aiValue);
 
-                                                if (existingList == null || !existingList.contains(aiValue)) {
-                                                    ops.rightPush(key, aiValue);
+										if (redistemplate.getExpire(key) == -1) {
+											redistemplate.expire(key, 1, TimeUnit.HOURS);
+										}
+									} else {
+										log.warn("중복 GREENI 음성 감지 - Redis 저장 생략: {}", aiValue);
+									}
+								}
+								return AIResponseDTO.DiaryResponse.of(
+									request.session_id(),
+									ttsRes.audioContent(),
+									diaryInnerResponse.reply(),
+									diaryInnerResponse.turn_count()
+								);
+							});
+					});
+			});
+	}
 
-                                                    if (redistemplate.getExpire(key) == -1) {
-                                                        redistemplate.expire(key, 1, TimeUnit.HOURS);
-                                                    }
-                                                } else {
-                                                    log.warn("중복 GREENI 음성 감지 - Redis 저장 생략: {}", aiValue);
-                                                }
-                                            }
-                                            return AIResponseDTO.DiaryResponse.of(
-                                                    request.session_id(),
-                                                    ttsRes.audioContent(),
-                                                    diaryInnerResponse.reply(),
-                                                    diaryInnerResponse.turn_count()
-                                            );
-                                        });
-                            });
-                });
-    }
+	public Mono<?> diaryClose(AIRequestDTO.DiaryCloseRequest request, Long memberId) {
+		// ai에게 대화 종료 요청 (ended)
+		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
+		String key = "diary:voice:" + memberId + ":" + request.profileId();
+		return aiWebClient.post()
+			.uri("/diary/end")
+			.bodyValue(request)   // session_id 포함된 DTO
+			.retrieve()
+			.bodyToMono(AIResponseDTO.DiaryAbnormalEndInnerResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.doOnError(WebClientResponseException.class, e ->
+				log.error("Diary End 에러: {}", e.getResponseBodyAsString())
+			)
+			.doOnSuccess(res -> {
+				redistemplate.delete(key);
+			});
+	}
 
-    public Mono<?> diaryClose(AIRequestDTO.DiaryCloseRequest request, Long memberId) {
-        // ai에게 대화 종료 요청 (ended)
-        Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
-        String key = "diary:voice:" + memberId + ":" + request.profileId();
-        return aiWebClient.post()
-                .uri("/diary/end")
-                .bodyValue(request)   // session_id 포함된 DTO
-                .retrieve()
-                .bodyToMono(AIResponseDTO.DiaryAbnormalEndInnerResponse.class)
-                .doOnError(WebClientResponseException.class, e ->
-                        log.error("Diary End 에러: {}", e.getResponseBodyAsString())
-                )
-                .doOnSuccess(res -> {
-                    redistemplate.delete(key);
-                });
-    }
+	@Transactional
+	public Mono<AIResponseDTO.DiaryCloseResponse> diarySummarize(AIRequestDTO.DiarySummarizeRequest request,
+		Long memberId) {
+		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
+		String key = "diary:voice:" + memberId + ":" + request.profileId();
 
-    @Transactional
-    public Mono<AIResponseDTO.DiaryCloseResponse> diarySummarize(AIRequestDTO.DiarySummarizeRequest request, Long memberId) {
-        Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
-        String key = "diary:voice:" + memberId + ":" + request.profileId();
+		AIRequestDTO.DiarySummarizeInnerRequest innerReq =
+			new AIRequestDTO.DiarySummarizeInnerRequest(
+				request.sessionId()
+			);
 
-        AIRequestDTO.DiarySummarizeInnerRequest innerReq =
-                new AIRequestDTO.DiarySummarizeInnerRequest(
-                        request.sessionId()
-                );
+		// db에 저장 후, 프론트에게 값 돌려주기
+		// ai에게 대화 요약 요청
+		return aiWebClient.post()
+			.uri("/diary/summarize")
+			.bodyValue(innerReq)
+			.retrieve()
+			.bodyToMono(AIResponseDTO.DiarySummarizeInnerResponse.class)
+			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
+				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.doOnError(WebClientResponseException.class, e ->
+				log.error("Diary Summarize 에러: {}", e.getResponseBodyAsString())
+			)
+			.flatMap(aiRes -> {
+				//  1. Redis에서 voice 리스트 조회
+				List<String> voiceRawList = redistemplate.opsForList().range(key, 0, -1);
 
-        // db에 저장 후, 프론트에게 값 돌려주기
-        // ai에게 대화 요약 요청
-        return aiWebClient.post()
-                .uri("/diary/summarize")
-                .bodyValue(innerReq)
-                .retrieve()
-                .bodyToMono(AIResponseDTO.DiarySummarizeInnerResponse.class)
-                .doOnError(WebClientResponseException.class, e ->
-                        log.error("Diary Summarize 에러: {}", e.getResponseBodyAsString())
-                )
-                .flatMap(aiRes -> {
-                    //  1. Redis에서 voice 리스트 조회
-                    List<String> voiceRawList = redistemplate.opsForList().range(key, 0, -1);
+				//  2. Diary 생성
+				Diary diary = Diary.builder()
+					.diaryImage(request.imageUrl())
+					.summary(aiRes.summary())
+					.emotion(Emotion.from(aiRes.emotion().primary()))
+					.keyword(aiRes.keyword())
+					.diaryDate(LocalDate.now())
+					.profile(profile)
+					.build();
 
-                    //  2. Diary 생성
-                    Diary diary = Diary.builder()
-                            .diaryImage(request.imageUrl())
-                            .summary(aiRes.summary())
-                            .emotion(Emotion.from(aiRes.emotion().primary()))
-                            .keyword(aiRes.keyword())
-                            .diaryDate(LocalDate.now())
-                            .profile(profile)
-                            .build();
+				//  3. Voice 변환
+				if (voiceRawList != null) {
+					for (String raw : voiceRawList) {
 
-                    //  3. Voice 변환
-                    if (voiceRawList != null) {
-                        for (String raw : voiceRawList) {
+						String[] parts = raw.split("\\|");
+						String roleStr = parts[0];
+						String url = parts[1];
 
-                            String[] parts = raw.split("\\|");
-                            String roleStr = parts[0];
-                            String url = parts[1];
+						Voice voice = Voice.builder()
+							.sessionId(request.sessionId())
+							.voiceUrl(url)
+							.voiceRole(
+								roleStr.equals("CHILD")
+									? VoiceRole.CHILD
+									: VoiceRole.GREENI
+							)
+							.diary(diary)
+							.build();
 
-                            Voice voice = Voice.builder()
-                                    .sessionId(request.sessionId())
-                                    .voiceUrl(url)
-                                    .voiceRole(
-                                            roleStr.equals("CHILD")
-                                                    ? VoiceRole.CHILD
-                                                    : VoiceRole.GREENI
-                                    )
-                                    .diary(diary)
-                                    .build();
+						diary.getVoiceList().add(voice);
+					}
+				}
 
-                            diary.getVoiceList().add(voice);
-                        }
-                    }
+				//  4. DB 저장
+				return Mono.fromCallable(() -> {
+						// 1. Diary 저장
+						Diary savedDiary = diaryRepository.save(diary);
 
-                    //  4. DB 저장
-                    return Mono.fromCallable(() -> {
-                                // 1. Diary 저장
-                                Diary savedDiary = diaryRepository.save(diary);
+						// 2. Activity 저장
+						String description = "일기 작성을 완료했습니다.";
+						Activity newActivity = ActivityConverter.toActivity(
+							ActivityType.DIARY, description, profile, null
+						);
+						activityService.checkTodayActivity(profile.getId());
+						activityRepository.save(newActivity);
 
-                                // 2. Activity 저장
-                                String description = "일기 작성을 완료했습니다.";
-                                Activity newActivity = ActivityConverter.toActivity(
-                                        ActivityType.DIARY, description, profile, null
-                                );
-                                activityService.checkTodayActivity(profile.getId());
-                                activityRepository.save(newActivity);
+						// 3. Badge 체크
+						badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
+						// 4. Redis 삭제
+						redistemplate.delete(key);
 
-                                // 3. Badge 체크
-                                badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
-                                // 4. Redis 삭제
-                                redistemplate.delete(key);
-
-                                return AIResponseDTO.DiaryCloseResponse.of(savedDiary.getId());
-                            })
-                            .subscribeOn(Schedulers.boundedElastic());
-                });
-    }
+						return AIResponseDTO.DiaryCloseResponse.of(savedDiary.getId());
+					})
+					.subscribeOn(Schedulers.boundedElastic());
+			});
+	}
 
 }

--- a/src/main/java/com/greeni/api/ai/service/AIService.java
+++ b/src/main/java/com/greeni/api/ai/service/AIService.java
@@ -20,11 +20,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import com.greeni.api.activities.converter.ActivityConverter;
-import com.greeni.api.activities.domain.Activity;
-import com.greeni.api.activities.domain.enums.ActivityType;
-import com.greeni.api.activities.repository.ActivityRepository;
-import com.greeni.api.activities.service.ActivityService;
 import com.greeni.api.ai.domain.Purpose;
 import com.greeni.api.ai.domain.RolePlayingType;
 import com.greeni.api.ai.dto.AIRequestDTO;
@@ -32,12 +27,8 @@ import com.greeni.api.ai.dto.AIResponseDTO;
 import com.greeni.api.apiPayload.handler.GeneralException;
 import com.greeni.api.apiPayload.status.CommonErrorStatus;
 import com.greeni.api.apiPayload.status.DiaryErrorStatus;
-import com.greeni.api.badges.service.BadgeService;
-import com.greeni.api.diaries.domain.Diary;
-import com.greeni.api.diaries.domain.Voice;
-import com.greeni.api.diaries.domain.enums.Emotion;
-import com.greeni.api.diaries.domain.enums.VoiceRole;
 import com.greeni.api.diaries.repository.DiaryRepository;
+import com.greeni.api.diaries.service.DiaryService;
 import com.greeni.api.profiles.domain.Profile;
 import com.greeni.api.profiles.service.ProfileQueryService;
 
@@ -56,11 +47,9 @@ public class AIService {
 
 	private final WebClient aiWebClient;
 	private final DiaryRepository diaryRepository;
-	private final RedisTemplate<String, String> redistemplate;
+	private final RedisTemplate<String, String> redisTemplate;
 	private final ProfileQueryService profileQueryService;
-	private final ActivityService activityService;
-	private final ActivityRepository activityRepository;
-	private final BadgeService badgeService;
+	private final DiaryService diaryService;
 
 	public Mono<AIResponseDTO.FiveQuestionsHintResponse> fiveQuestionsHint(AIRequestDTO.FiveQuestionsHint request) {
 
@@ -71,8 +60,7 @@ public class AIService {
 			.bodyValue(request)
 			.retrieve()
 			.bodyToMono(AIResponseDTO.FiveQuestionsHintText.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.retryWhen(webClientRetrySpec())
 			.flatMap(context -> {
 				List<String> hintList = context.hints();
 				if (hintList == null) {
@@ -94,8 +82,7 @@ public class AIService {
 							.bodyValue(ttsRequest)
 							.retrieve()
 							.bodyToMono(AIResponseDTO.TTSResponse.class)
-							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-								.filter(throwable -> throwable instanceof WebClientRequestException))
+							.retryWhen(webClientRetrySpec())
 							.doOnError(WebClientResponseException.class, e -> {
 								log.error("TTS 에러: {}", e.getResponseBodyAsString());
 							})
@@ -113,40 +100,39 @@ public class AIService {
 
 		Purpose purpose = Purpose.FIVEQ;
 
-		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
-
-		return aiWebClient.post()
-			.uri("/stt/transcribe")
-			.body(BodyInserters.fromMultipartData(builder.build()))
-			.retrieve()
-			.bodyToMono(AIResponseDTO.STTResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
-			.doOnError(WebClientResponseException.class, e -> {
-				log.error("STT 에러: {}", e.getResponseBodyAsString());
-			})
-			.flatMap(sttRes -> {
-				String recognizedText = sttRes.text();
-				log.debug("아이가 한 말: {}", recognizedText);
-
-				AIRequestDTO.FiveQuestionsCheckInner checkInnerReq = new AIRequestDTO.FiveQuestionsCheckInner(
-					recognizedText,
-					request.answer()
-				);
-
+		return buildVoiceMultipart(request.voice(), purpose, null)
+			.flatMap(builder -> {
 				return aiWebClient.post()
-					.uri("/game/fiveq/check")
-					.bodyValue(checkInnerReq)
+					.uri("/stt/transcribe")
+					.body(BodyInserters.fromMultipartData(builder.build()))
 					.retrieve()
-					.bodyToMono(AIResponseDTO.FiveQuestionsCheckAnswer.class)
-					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-						.filter(throwable -> throwable instanceof WebClientRequestException))
-					.doOnError(e -> log.error("FiveQ Check 에러: {}", e.getMessage()))
-					.map(checkAns -> {
-						Boolean correct = checkAns.correct();
-						return AIResponseDTO.FiveQuestionsCheckResponse.of(
-							correct, null
+					.bodyToMono(AIResponseDTO.STTResponse.class)
+					.retryWhen(webClientRetrySpec())
+					.doOnError(WebClientResponseException.class, e -> {
+						log.error("STT 에러: {}", e.getResponseBodyAsString());
+					})
+					.flatMap(sttRes -> {
+						String recognizedText = sttRes.text();
+						log.debug("아이가 한 말: {}", recognizedText);
+
+						AIRequestDTO.FiveQuestionsCheckInner checkInnerReq = new AIRequestDTO.FiveQuestionsCheckInner(
+							recognizedText,
+							request.answer()
 						);
+
+						return aiWebClient.post()
+							.uri("/game/fiveq/check")
+							.bodyValue(checkInnerReq)
+							.retrieve()
+							.bodyToMono(AIResponseDTO.FiveQuestionsCheckAnswer.class)
+							.retryWhen(webClientRetrySpec())
+							.doOnError(e -> log.error("FiveQ Check 에러: {}", e.getMessage()))
+							.map(checkAns -> {
+								Boolean correct = checkAns.correct();
+								return AIResponseDTO.FiveQuestionsCheckResponse.of(
+									correct, null
+								);
+							});
 					});
 			});
 	}
@@ -156,51 +142,50 @@ public class AIService {
 		Purpose purpose = Purpose.ROLEPLAY;
 		RolePlayingType type = RolePlayingType.valueOf(request.role().toUpperCase());
 
-		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
-
-		return aiWebClient.post()
-			.uri("/stt/transcribe")
-			.body(BodyInserters.fromMultipartData(builder.build()))
-			.retrieve()
-			.bodyToMono(AIResponseDTO.STTResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
-			.doOnError(WebClientResponseException.class, e -> {
-				log.error("STT 에러: {}", e.getResponseBodyAsString());
-			})
-			.flatMap(sttRes -> {
-				String recognizedText = sttRes.text();
-				log.debug("아이가 한 말: {}", recognizedText);
-
-				AIRequestDTO.RolePlayingInner rolePlayingReq = new AIRequestDTO.RolePlayingInner(
-					request.sessionId(), type, recognizedText, null, null, null
-				);
-
+		// buildVoiceMultipart의 반환값이 Mono이므로 flatMap으로 체이닝
+		return buildVoiceMultipart(request.voice(), purpose, null)
+			.flatMap(builder -> {
 				return aiWebClient.post()
-					.uri("/chat/roleplay")
-					.bodyValue(rolePlayingReq)
+					.uri("/stt/transcribe")
+					.body(BodyInserters.fromMultipartData(builder.build()))
 					.retrieve()
-					.bodyToMono(AIResponseDTO.RolePlayingInnerResponse.class)
-					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-						.filter(throwable -> throwable instanceof WebClientRequestException))
-					.doOnError(e -> log.error("RolePlaying 에러: {}", e.getMessage()))
-					.flatMap(roleRes -> {
-						AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
-							purpose, roleRes.reply(), null, null, null
+					.bodyToMono(AIResponseDTO.STTResponse.class)
+					.retryWhen(webClientRetrySpec())
+					.doOnError(WebClientResponseException.class, e -> {
+						log.error("STT 에러: {}", e.getResponseBodyAsString());
+					})
+					.flatMap(sttRes -> {
+						String recognizedText = sttRes.text();
+						log.debug("아이가 한 말: {}", recognizedText);
+
+						AIRequestDTO.RolePlayingInner rolePlayingReq = new AIRequestDTO.RolePlayingInner(
+							request.sessionId(), type, recognizedText, null, null, null
 						);
+
 						return aiWebClient.post()
-							.uri("/tts/speak")
-							.bodyValue(ttsRequest)
+							.uri("/chat/roleplay")
+							.bodyValue(rolePlayingReq)
 							.retrieve()
-							.bodyToMono(AIResponseDTO.TTSResponse.class)
-							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-								.filter(throwable -> throwable instanceof WebClientRequestException))
-							.doOnError(WebClientResponseException.class, e -> {
-								log.error("TTS 에러: {}", e.getResponseBodyAsString());
-							})
-							.map(base64Audio -> AIResponseDTO.RolePlayingResponse.of(
-								request.sessionId(), base64Audio.audioContent(), roleRes.reply(), roleRes.turn()
-							));
+							.bodyToMono(AIResponseDTO.RolePlayingInnerResponse.class)
+							.retryWhen(webClientRetrySpec())
+							.doOnError(e -> log.error("RolePlaying 에러: {}", e.getMessage()))
+							.flatMap(roleRes -> {
+								AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
+									purpose, roleRes.reply(), null, null, null
+								);
+								return aiWebClient.post()
+									.uri("/tts/speak")
+									.bodyValue(ttsRequest)
+									.retrieve()
+									.bodyToMono(AIResponseDTO.TTSResponse.class)
+									.retryWhen(webClientRetrySpec())
+									.doOnError(WebClientResponseException.class, e -> {
+										log.error("TTS 에러: {}", e.getResponseBodyAsString());
+									})
+									.map(base64Audio -> AIResponseDTO.RolePlayingResponse.of(
+										request.sessionId(), base64Audio.audioContent(), roleRes.reply(), roleRes.turn()
+									));
+							});
 					});
 			});
 	}
@@ -211,227 +196,190 @@ public class AIService {
 			.bodyValue(request)
 			.retrieve()
 			.bodyToMono(AIResponseDTO.RolePlayingEndResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
+			.retryWhen(webClientRetrySpec())
 			.map(result -> AIResponseDTO.RolePlayingEndResponse.of(request.sessionId()));
 	}
 
-	private MultipartBodyBuilder buildVoiceMultipart(MultipartFile voice, Purpose purpose, String sessionId) {
+	private Mono<MultipartBodyBuilder> buildVoiceMultipart(MultipartFile voice, Purpose purpose, String sessionId) {
+		return Mono.fromCallable(() -> {
+			MultipartBodyBuilder builder = new MultipartBodyBuilder();
 
-		MultipartBodyBuilder builder = new MultipartBodyBuilder();
+			try {
+				byte[] voiceBytes = voice.getBytes();
+				String originalFileName = voice.getOriginalFilename();
 
-		try {
-			byte[] voiceBytes = voice.getBytes();
-			String originalFileName = voice.getOriginalFilename();
+				if (originalFileName == null || originalFileName.isEmpty()) {
+					originalFileName = "audio.mp4";
+				}
 
-			if (originalFileName == null || originalFileName.isEmpty()) {
-				originalFileName = "audio.mp4";
+				builder.part("voice", new ByteArrayResource(voiceBytes))
+					.filename(originalFileName)
+					.contentType(MediaType.parseMediaType("audio/mp4"));
+			} catch (IOException e) {
+				throw new GeneralException(CommonErrorStatus.VOICE_PARSING_ERROR);
 			}
 
-			builder.part("voice", new ByteArrayResource(voiceBytes))
-				.filename(originalFileName)
-				.contentType(MediaType.parseMediaType("audio/mp4"));
-		} catch (IOException e) {
-			throw new GeneralException(CommonErrorStatus.VOICE_PARSING_ERROR);
-		}
-		builder.part("purpose", purpose.getName());
-		if (sessionId != null) {
-			builder.part("session_id", sessionId);
-		}
+			builder.part("purpose", purpose.getName());
+			if (sessionId != null) {
+				builder.part("session_id", sessionId);
+			}
 
-		return builder;
+			return builder;
+		}).subscribeOn(Schedulers.boundedElastic());
 	}
 
 	// 일기 대화 요청 로직
 	public Mono<AIResponseDTO.DiaryResponse> diary(AIRequestDTO.DiaryRequest request, Long memberId) {
-		// 프론트에서 받은 s3 redis에 저장하는 로직
-		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
 
-		if (diaryRepository.findByProfileIdAndDiaryDate(profile.getId(), LocalDate.now()).isPresent()) {
-			throw new GeneralException(DiaryErrorStatus.EXIST_TODAY_DIARY);
-		}
+		return Mono.fromCallable(() -> {
+				Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
 
-		ListOperations<String, String> ops = redistemplate.opsForList();
-		String key = "diary:voice:" + memberId + ":" + request.profileId();
-		String value = "CHILD|" + request.voiceUrl();
-		ops.rightPush(key, value);
-		if (redistemplate.getExpire(key) == -1) {
-			redistemplate.expire(key, 1, TimeUnit.HOURS);
-		}
+				if (diaryRepository.findByProfileIdAndDiaryDate(profile.getId(), LocalDate.now()).isPresent()) {
+					throw new GeneralException(DiaryErrorStatus.EXIST_TODAY_DIARY);
+				}
 
-		// 일기 요청 대화 로직
-		Purpose purpose = Purpose.DIARY;
+				ListOperations<String, String> ops = redisTemplate.opsForList();
+				String key = "diary:voice:" + memberId + ":" + request.profileId();
+				String value = "CHILD|" + request.voiceUrl();
+				ops.rightPush(key, value);
 
-		MultipartBodyBuilder builder = buildVoiceMultipart(request.voice(), purpose, null);
+				if (redisTemplate.getExpire(key) == -1) {
+					redisTemplate.expire(key, 1, TimeUnit.HOURS);
+				}
 
-		return aiWebClient.post()
-			.uri("/stt/transcribe")
-			.body(BodyInserters.fromMultipartData(builder.build()))
-			.retrieve()
-			.bodyToMono(AIResponseDTO.STTResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
-			.doOnError(WebClientResponseException.class, e -> {
-				log.error("STT 에러: {}", e.getResponseBodyAsString());
+				return profile;
 			})
-			.flatMap(sttRes -> {
-				String recognizedText = sttRes.text();
-				log.debug("아이가 한 말: {}", recognizedText);
+			.subscribeOn(Schedulers.boundedElastic())
+			.flatMap(profile -> {
+				Purpose purpose = Purpose.DIARY;
 
-				AIRequestDTO.DiaryInner diaryReq = new AIRequestDTO.DiaryInner(
-					request.session_id(), recognizedText
-				);
-
-				return aiWebClient.post()
-					.uri("/diary/chat")
-					.bodyValue(diaryReq)
-					.retrieve()
-					.bodyToMono(AIResponseDTO.DiaryInnerResponse.class)
-					.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-						.filter(throwable -> throwable instanceof WebClientRequestException))
-					.doOnError(e -> log.error("Diary 에러: {}", e.getMessage()))
-					.flatMap(diaryInnerResponse -> {
-						AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
-							purpose, diaryInnerResponse.reply(), null, null, null
-						);
+				// 💡 비동기 체이닝으로 MultipartBodyBuilder 생성 후 WebClient 요청
+				return buildVoiceMultipart(request.voice(), purpose, null)
+					.flatMap(builder -> {
 						return aiWebClient.post()
-							.uri("/tts/speak")
-							.bodyValue(ttsRequest)
+							.uri("/stt/transcribe")
+							.body(BodyInserters.fromMultipartData(builder.build()))
 							.retrieve()
-							.bodyToMono(AIResponseDTO.TTSResponse.class)
-							.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-								.filter(throwable -> throwable instanceof WebClientRequestException))
+							.bodyToMono(AIResponseDTO.STTResponse.class)
+							.retryWhen(webClientRetrySpec())
 							.doOnError(WebClientResponseException.class, e ->
-								log.error("TTS 에러: {}", e.getResponseBodyAsString())
+								log.error("STT 에러: {}", e.getResponseBodyAsString())
 							)
-							// ai서버로부터 온 s3 url 저장 로직
-							.map(ttsRes -> {
-								if (ttsRes.audioUrl() != null) {
-									String aiValue = "GREENI|" + ttsRes.audioUrl();
-									List<String> existingList = ops.range(key, 0, -1);
+							.flatMap(sttRes -> {
+								String recognizedText = sttRes.text();
+								log.debug("아이가 한 말: {}", recognizedText);
 
-									if (existingList == null || !existingList.contains(aiValue)) {
-										ops.rightPush(key, aiValue);
-
-										if (redistemplate.getExpire(key) == -1) {
-											redistemplate.expire(key, 1, TimeUnit.HOURS);
-										}
-									} else {
-										log.warn("중복 GREENI 음성 감지 - Redis 저장 생략: {}", aiValue);
-									}
-								}
-								return AIResponseDTO.DiaryResponse.of(
-									request.session_id(),
-									ttsRes.audioContent(),
-									diaryInnerResponse.reply(),
-									diaryInnerResponse.turn_count()
+								AIRequestDTO.DiaryInner diaryReq = new AIRequestDTO.DiaryInner(
+									request.session_id(), recognizedText
 								);
+
+								return aiWebClient.post()
+									.uri("/diary/chat")
+									.bodyValue(diaryReq)
+									.retrieve()
+									.bodyToMono(AIResponseDTO.DiaryInnerResponse.class)
+									.retryWhen(webClientRetrySpec())
+									.doOnError(e -> log.error("Diary 에러: {}", e.getMessage()))
+									.flatMap(diaryInnerResponse -> {
+										AIRequestDTO.TTSRequest ttsRequest = new AIRequestDTO.TTSRequest(
+											purpose, diaryInnerResponse.reply(), null, null, null
+										);
+
+										return aiWebClient.post()
+											.uri("/tts/speak")
+											.bodyValue(ttsRequest)
+											.retrieve()
+											.bodyToMono(AIResponseDTO.TTSResponse.class)
+											.retryWhen(webClientRetrySpec())
+											.doOnError(WebClientResponseException.class, e ->
+												log.error("TTS 에러: {}", e.getResponseBodyAsString())
+											)
+											.flatMap(ttsRes -> Mono.fromCallable(() -> {
+												if (ttsRes.audioUrl() != null) {
+													String key = "diary:voice:" + memberId + ":" + request.profileId();
+													ListOperations<String, String> ops = redisTemplate.opsForList();
+													String aiValue = "GREENI|" + ttsRes.audioUrl();
+													List<String> existingList = ops.range(key, 0, -1);
+
+													if (existingList == null || !existingList.contains(aiValue)) {
+														ops.rightPush(key, aiValue);
+														if (redisTemplate.getExpire(key) == -1) {
+															redisTemplate.expire(key, 1, TimeUnit.HOURS);
+														}
+													} else {
+														log.warn("중복 GREENI 음성 감지 - Redis 저장 생략: {}", aiValue);
+													}
+												}
+												return AIResponseDTO.DiaryResponse.of(
+													request.session_id(),
+													ttsRes.audioContent(),
+													diaryInnerResponse.reply(),
+													diaryInnerResponse.turn_count()
+												);
+											}).subscribeOn(Schedulers.boundedElastic()));
+									});
 							});
 					});
 			});
 	}
 
 	public Mono<?> diaryClose(AIRequestDTO.DiaryCloseRequest request, Long memberId) {
-		// ai에게 대화 종료 요청 (ended)
-		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
-		String key = "diary:voice:" + memberId + ":" + request.profileId();
-		return aiWebClient.post()
-			.uri("/diary/end")
-			.bodyValue(request)   // session_id 포함된 DTO
-			.retrieve()
-			.bodyToMono(AIResponseDTO.DiaryAbnormalEndInnerResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
-			.doOnError(WebClientResponseException.class, e ->
-				log.error("Diary End 에러: {}", e.getResponseBodyAsString())
-			)
-			.doOnSuccess(res -> {
-				redistemplate.delete(key);
+		return Mono.fromCallable(() -> profileQueryService.findProfileAndValidate(request.profileId(), memberId))
+			.subscribeOn(Schedulers.boundedElastic())
+			.flatMap(profile -> {
+				String key = "diary:voice:" + memberId + ":" + request.profileId();
+
+				return aiWebClient.post()
+					.uri("/diary/end")
+					.bodyValue(request)
+					.retrieve()
+					.bodyToMono(AIResponseDTO.DiaryAbnormalEndInnerResponse.class)
+					.retryWhen(webClientRetrySpec())
+					.doOnError(WebClientResponseException.class, e ->
+						log.error("Diary End 에러: {}", e.getResponseBodyAsString())
+					)
+					.flatMap(res -> Mono.fromRunnable(() -> redisTemplate.delete(key))
+						.subscribeOn(Schedulers.boundedElastic())
+						.thenReturn(res)
+					);
 			});
 	}
 
-	@Transactional
 	public Mono<AIResponseDTO.DiaryCloseResponse> diarySummarize(AIRequestDTO.DiarySummarizeRequest request,
 		Long memberId) {
-		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
-		String key = "diary:voice:" + memberId + ":" + request.profileId();
 
-		AIRequestDTO.DiarySummarizeInnerRequest innerReq =
-			new AIRequestDTO.DiarySummarizeInnerRequest(
-				request.sessionId()
-			);
+		return Mono.fromCallable(() -> profileQueryService.findProfileAndValidate(request.profileId(), memberId))
+			.subscribeOn(Schedulers.boundedElastic())
+			.flatMap(profile -> {
+				String key = "diary:voice:" + memberId + ":" + request.profileId();
+				AIRequestDTO.DiarySummarizeInnerRequest innerReq = new AIRequestDTO.DiarySummarizeInnerRequest(
+					request.sessionId());
 
-		// db에 저장 후, 프론트에게 값 돌려주기
-		// ai에게 대화 요약 요청
-		return aiWebClient.post()
-			.uri("/diary/summarize")
-			.bodyValue(innerReq)
-			.retrieve()
-			.bodyToMono(AIResponseDTO.DiarySummarizeInnerResponse.class)
-			.retryWhen(Retry.backoff(2, Duration.ofSeconds(2))
-				.filter(throwable -> throwable instanceof WebClientRequestException))
-			.doOnError(WebClientResponseException.class, e ->
-				log.error("Diary Summarize 에러: {}", e.getResponseBodyAsString())
-			)
-			.flatMap(aiRes -> {
-				//  1. Redis에서 voice 리스트 조회
-				List<String> voiceRawList = redistemplate.opsForList().range(key, 0, -1);
-
-				//  2. Diary 생성
-				Diary diary = Diary.builder()
-					.diaryImage(request.imageUrl())
-					.summary(aiRes.summary())
-					.emotion(Emotion.from(aiRes.emotion().primary()))
-					.keyword(aiRes.keyword())
-					.diaryDate(LocalDate.now())
-					.profile(profile)
-					.build();
-
-				//  3. Voice 변환
-				if (voiceRawList != null) {
-					for (String raw : voiceRawList) {
-
-						String[] parts = raw.split("\\|");
-						String roleStr = parts[0];
-						String url = parts[1];
-
-						Voice voice = Voice.builder()
-							.sessionId(request.sessionId())
-							.voiceUrl(url)
-							.voiceRole(
-								roleStr.equals("CHILD")
-									? VoiceRole.CHILD
-									: VoiceRole.GREENI
+				return aiWebClient.post()
+					.uri("/diary/summarize")
+					.bodyValue(innerReq)
+					.retrieve()
+					.bodyToMono(AIResponseDTO.DiarySummarizeInnerResponse.class)
+					.retryWhen(webClientRetrySpec())
+					.doOnError(WebClientResponseException.class, e ->
+						log.error("Diary Summarize 에러: {}", e.getResponseBodyAsString())
+					)
+					.flatMap(aiRes -> {
+						return Mono.fromCallable(() ->
+							diaryService.finalizeDiaryAndActivities(
+								profile,
+								request.sessionId(),
+								request.imageUrl(),
+								aiRes,
+								key
 							)
-							.diary(diary)
-							.build();
-
-						diary.getVoiceList().add(voice);
-					}
-				}
-
-				//  4. DB 저장
-				return Mono.fromCallable(() -> {
-						// 1. Diary 저장
-						Diary savedDiary = diaryRepository.save(diary);
-
-						// 2. Activity 저장
-						String description = "일기 작성을 완료했습니다.";
-						Activity newActivity = ActivityConverter.toActivity(
-							ActivityType.DIARY, description, profile, null
-						);
-						activityService.checkTodayActivity(profile.getId());
-						activityRepository.save(newActivity);
-
-						// 3. Badge 체크
-						badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
-						// 4. Redis 삭제
-						redistemplate.delete(key);
-
-						return AIResponseDTO.DiaryCloseResponse.of(savedDiary.getId());
-					})
-					.subscribeOn(Schedulers.boundedElastic());
+						).subscribeOn(Schedulers.boundedElastic());
+					});
 			});
 	}
 
+	private Retry webClientRetrySpec() {
+		return Retry.backoff(2, Duration.ofSeconds(2))
+			.filter(throwable -> throwable instanceof WebClientRequestException);
+	}
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryService.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryService.java
@@ -1,25 +1,32 @@
 package com.greeni.api.diaries.service;
 
+import com.greeni.api.ai.dto.AIResponseDTO;
 import com.greeni.api.diaries.dto.DiaryRequestDTO;
 import com.greeni.api.diaries.dto.DiaryResponseDTO;
 import com.greeni.api.profiles.domain.Profile;
-import jakarta.validation.Valid;
 
 public interface DiaryService {
 
-    // 오늘의 일기 키워드 조회
-    DiaryResponseDTO.GetTodayDiaryKeywordResponse getTodayDiaryKeyword(Long memberId, Long profileId);
+	AIResponseDTO.DiaryCloseResponse finalizeDiaryAndActivities(
+		Profile profile,
+		String sessionId,
+		String imageUrl,
+		AIResponseDTO.DiarySummarizeInnerResponse aiRes,
+		String redisKey);
 
-    // 이번 달 일기 감정 통계 조회
-    DiaryResponseDTO.GetMonthlyDiaryEmotionResponse getMonthlyDiaryEmotion(Long memberId, Long profileId);
+	// 오늘의 일기 키워드 조회
+	DiaryResponseDTO.GetTodayDiaryKeywordResponse getTodayDiaryKeyword(Long memberId, Long profileId);
 
-    DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId);
+	// 이번 달 일기 감정 통계 조회
+	DiaryResponseDTO.GetMonthlyDiaryEmotionResponse getMonthlyDiaryEmotion(Long memberId, Long profileId);
 
-    DiaryResponseDTO.DailyDiaryDTO getDailyDiary(int year, int month, int day, Long id, Long profileId);
+	DiaryResponseDTO.MonthDiaryListDTO getMonthDiaryList(int year, int month, Long memberId, Long profileId);
 
-    DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId);
+	DiaryResponseDTO.DailyDiaryDTO getDailyDiary(int year, int month, int day, Long id, Long profileId);
 
-    // DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request);
+	DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId);
 
-    void getVoiceUrl(Long id, DiaryRequestDTO.DiaryUrlDTO request);
+	// DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request);
+
+	void getVoiceUrl(Long id, DiaryRequestDTO.DiaryUrlDTO request);
 }

--- a/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
+++ b/src/main/java/com/greeni/api/diaries/service/DiaryServiceImpl.java
@@ -7,33 +7,32 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.greeni.api.activities.converter.ActivityConverter;
 import com.greeni.api.activities.domain.Activity;
 import com.greeni.api.activities.domain.enums.ActivityType;
 import com.greeni.api.activities.repository.ActivityRepository;
 import com.greeni.api.activities.service.ActivityService;
-import com.greeni.api.badges.service.BadgeService;
-import com.greeni.api.diaries.converter.VoiceConverter;
-import com.greeni.api.diaries.dto.DiaryRequestDTO;
-import com.greeni.api.profiles.service.ProfileQueryService;
-import jakarta.validation.Valid;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
+import com.greeni.api.ai.dto.AIResponseDTO;
 import com.greeni.api.apiPayload.handler.GeneralException;
 import com.greeni.api.apiPayload.status.DiaryErrorStatus;
-import com.greeni.api.apiPayload.status.ProfileErrorStatus;
+import com.greeni.api.badges.service.BadgeService;
 import com.greeni.api.diaries.converter.DiaryConverter;
 import com.greeni.api.diaries.domain.Diary;
 import com.greeni.api.diaries.domain.Voice;
+import com.greeni.api.diaries.domain.enums.Emotion;
+import com.greeni.api.diaries.domain.enums.VoiceRole;
+import com.greeni.api.diaries.dto.DiaryRequestDTO;
 import com.greeni.api.diaries.dto.DiaryResponseDTO;
 import com.greeni.api.diaries.repository.DiaryRepository;
 import com.greeni.api.diaries.repository.VoiceRepository;
 import com.greeni.api.profiles.domain.Profile;
 import com.greeni.api.profiles.repository.ProfileRepository;
+import com.greeni.api.profiles.service.ProfileQueryService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,14 +43,70 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class DiaryServiceImpl implements DiaryService {
 
-    private final ProfileRepository profileRepository;
+	private final ProfileRepository profileRepository;
 	private final ProfileQueryService profileQueryService;
 	private final ActivityRepository activityRepository;
-    private final DiaryRepository diaryRepository;
-    private final VoiceRepository voiceRepository;
+	private final DiaryRepository diaryRepository;
+	private final VoiceRepository voiceRepository;
 	private final ActivityService activityService;
 	private final BadgeService badgeService;
-	private final RedisTemplate<String, String> redistemplate;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	@Transactional
+	public AIResponseDTO.DiaryCloseResponse finalizeDiaryAndActivities(
+		Profile profile,
+		String sessionId,
+		String imageUrl,
+		AIResponseDTO.DiarySummarizeInnerResponse aiRes,
+		String redisKey) {
+
+		// 1. Redis에서 Voice 데이터 조회
+		List<String> voiceRawList = redisTemplate.opsForList().range(redisKey, 0, -1);
+
+		// 2. Diary 엔티티 생성
+		Diary diary = Diary.builder()
+			.diaryImage(imageUrl)
+			.summary(aiRes.summary())
+			.emotion(Emotion.from(aiRes.emotion().primary()))
+			.keyword(aiRes.keyword())
+			.diaryDate(LocalDate.now())
+			.profile(profile)
+			.build();
+
+		// 3. Voice 엔티티 조립
+		if (voiceRawList != null) {
+			for (String raw : voiceRawList) {
+				String[] parts = raw.split("\\|");
+				Voice voice = Voice.builder()
+					.sessionId(sessionId)
+					.voiceUrl(parts[1])
+					.voiceRole(parts[0].equals("CHILD") ? VoiceRole.CHILD : VoiceRole.GREENI)
+					.diary(diary)
+					.build();
+				diary.getVoiceList().add(voice);
+			}
+		}
+
+		// 4. DB 저장 (Diary & Voices - Cascade 설정이 되어있다고 가정)
+		Diary savedDiary = diaryRepository.save(diary);
+
+		// 5. Activity(활동 기록) 저장
+		String description = "일기 작성을 완료했습니다.";
+		Activity newActivity = ActivityConverter.toActivity(
+			ActivityType.DIARY, description, profile, null
+		);
+		activityService.checkTodayActivity(profile.getId());
+		activityRepository.save(newActivity);
+
+		// 6. 배지 획득 여부 체크
+		badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
+
+		// 7. 처리가 모두 끝났으므로 Redis 데이터 삭제
+		redisTemplate.delete(redisKey);
+
+		return AIResponseDTO.DiaryCloseResponse.of(savedDiary.getId());
+	}
 
 	// 오늘의 일기 키워드 조회
 	@Override
@@ -119,9 +174,10 @@ public class DiaryServiceImpl implements DiaryService {
 		LocalDateTime start = startDate.atStartOfDay();
 		LocalDateTime end = endDate.atStartOfDay();
 
-        List<Diary> diaryList = diaryRepository.findByProfileIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(profileId, start, end);
-        return DiaryConverter.toMonthDiaryListDTO(profileId, diaryList);
-    }
+		List<Diary> diaryList = diaryRepository.findByProfileIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(
+			profileId, start, end);
+		return DiaryConverter.toMonthDiaryListDTO(profileId, diaryList);
+	}
 
 	@Override
 	@Transactional(readOnly = true)
@@ -129,81 +185,81 @@ public class DiaryServiceImpl implements DiaryService {
 
 		profileQueryService.findProfileAndValidate(profileId, memberId);
 
-        LocalDate requestDate =  checkDateValidate(year, month, day);
+		LocalDate requestDate = checkDateValidate(year, month, day);
 
+		// 조회
+		Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
+			.orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
 
-        // 조회
-        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
-                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
+		return DiaryConverter.toDailyDiaryDTO(profileId, diary);
+	}
 
-        return DiaryConverter.toDailyDiaryDTO(profileId, diary);
-    }
-
-    @Override
-    @Transactional(readOnly=true)
-    public DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId, Long profileId) {
+	@Override
+	@Transactional(readOnly = true)
+	public DiaryResponseDTO.DiaryVoiceListDTO getDiaryVoice(int year, int month, int day, Long memberId,
+		Long profileId) {
 
 		profileQueryService.findProfileAndValidate(profileId, memberId);
 
-        LocalDate requestDate = checkDateValidate(year, month, day);
+		LocalDate requestDate = checkDateValidate(year, month, day);
 
-        // 날짜 기준으로 일기 조회
+		// 날짜 기준으로 일기 조회
 
-        Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
-                .orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
-        // 음성 리스트 뽑기
-        List<Voice> voiceList = voiceRepository.findByDiaryIdOrderByCreatedAtAsc(diary.getId());
+		Diary diary = diaryRepository.findByProfileIdAndDiaryDate(profileId, requestDate)
+			.orElseThrow(() -> new GeneralException(DiaryErrorStatus.NOT_WRITE_DIARY));
+		// 음성 리스트 뽑기
+		List<Voice> voiceList = voiceRepository.findByDiaryIdOrderByCreatedAtAsc(diary.getId());
 
-        return DiaryConverter.toDiaryVoiceListDTO(voiceList, diary.getId());
-    }
+		return DiaryConverter.toDiaryVoiceListDTO(voiceList, diary.getId());
+	}
 
-    public LocalDate checkDateValidate(int year, int month, int day){
-        // 월 검증
-        if(month < 1 || month > 12){
-            throw new GeneralException(DiaryErrorStatus.INVALID_MONTH);
-        }
+	public LocalDate checkDateValidate(int year, int month, int day) {
+		// 월 검증
+		if (month < 1 || month > 12) {
+			throw new GeneralException(DiaryErrorStatus.INVALID_MONTH);
+		}
 
-        // 날짜 검증
-        YearMonth requestYm = YearMonth.of(year, month);
-        int lastDay = requestYm.lengthOfMonth();
-        if(day < 1 || day > lastDay){
-            throw new GeneralException(DiaryErrorStatus.INVALID_DAY);
-        }
+		// 날짜 검증
+		YearMonth requestYm = YearMonth.of(year, month);
+		int lastDay = requestYm.lengthOfMonth();
+		if (day < 1 || day > lastDay) {
+			throw new GeneralException(DiaryErrorStatus.INVALID_DAY);
+		}
 
-        // 미래 날짜 검증
-        LocalDate requestDate = LocalDate.of(year, month, day);
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        if(requestDate.isAfter(today)){
-            throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
-        }
-        return requestDate;
-    }
+		// 미래 날짜 검증
+		LocalDate requestDate = LocalDate.of(year, month, day);
+		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		if (requestDate.isAfter(today)) {
+			throw new GeneralException(DiaryErrorStatus.FUTURE_TIME);
+		}
+		return requestDate;
+	}
 
-//	@Override
-//	public DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request) {
-//		Profile profile = profileQueryService.findProfileAndValidate(request.getProfileId(), memberId);
-//
-//		Diary diary = DiaryConverter.toDiary(request, profile);
-//		diaryRepository.save(diary);
-//		ListOperations<String, String> ops = redistemplate.opsForList();
-//		String key = "diary:voice:" + memberId + ":" + request.getProfileId();
-//		List<String> urls = ops.range(key, 0, -1);
-//		if(urls.isEmpty()){
-//			throw new GeneralException(DiaryErrorStatus.NOT_DIARY_VOICE);
-//		}
-//		List<Voice> voiceList = VoiceConverter.toVoice(urls, request.getSessionId(), diary);
-//		voiceRepository.saveAll(voiceList);
-//
-//		String description = "일기 작성을 완료했습니다.";
-//		Activity newActivity = ActivityConverter.toActivity(
-//				ActivityType.DIARY, description, profile, null);
-//		activityService.checkTodayActivity(profile);
-//		activityRepository.save(newActivity);
-//
-//		badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
-//
-//		return DiaryConverter.toCreateDiaryDTO(diary.getId());
-//	}
+	//	@Override
+	//	public DiaryResponseDTO.CreateDiaryDTO createDiary(Long memberId, DiaryRequestDTO.DiarySaveDTO request) {
+	//		Profile profile = profileQueryService.findProfileAndValidate(request.getProfileId(), memberId);
+	//
+	//		Diary diary = DiaryConverter.toDiary(request, profile);
+	//		diaryRepository.save(diary);
+	//		ListOperations<String, String> ops = redistemplate.opsForList();
+	//		String key = "diary:voice:" + memberId + ":" + request.getProfileId();
+	//		List<String> urls = ops.range(key, 0, -1);
+	//		if(urls.isEmpty()){
+	//			throw new GeneralException(DiaryErrorStatus.NOT_DIARY_VOICE);
+	//		}
+	//		List<Voice> voiceList = VoiceConverter.toVoice(urls, request.getSessionId(), diary);
+	//		voiceRepository.saveAll(voiceList);
+	//
+	//		String description = "일기 작성을 완료했습니다.";
+	//		Activity newActivity = ActivityConverter.toActivity(
+	//				ActivityType.DIARY, description, profile, null);
+	//		activityService.checkTodayActivity(profile);
+	//		activityRepository.save(newActivity);
+	//
+	//		badgeService.checkAndAwardBadge(profile, ActivityType.DIARY);
+	//
+	//		return DiaryConverter.toCreateDiaryDTO(diary.getId());
+	//	}
 
 	@Override
 	public void getVoiceUrl(Long memberId, DiaryRequestDTO.DiaryUrlDTO request) {
@@ -211,12 +267,12 @@ public class DiaryServiceImpl implements DiaryService {
 		Profile profile = profileQueryService.findProfileAndValidate(request.profileId(), memberId);
 
 		// redis에 일기 url 저장하기
-		ListOperations<String, String> ops = redistemplate.opsForList();
+		ListOperations<String, String> ops = redisTemplate.opsForList();
 		String key = "diary:voice:" + memberId + ":" + request.profileId();
 		String value = request.role() + "|" + request.url();
 		ops.rightPush(key, value);
-		if(redistemplate.getExpire(key) == -1) {
-			redistemplate.expire(key, 1, TimeUnit.HOURS);
+		if (redisTemplate.getExpire(key) == -1) {
+			redisTemplate.expire(key, 1, TimeUnit.HOURS);
 		}
 	}
 


### PR DESCRIPTION
## 💡 관련 이슈
- X

## 📢 작업 내용
- AI 서버 에러 응답 시 재요청(Retry)하는 공통 로직 추가

- WebFlux 메인 스레드(Netty) 블로킹 방지를 위한 DB/Redis/File I/O 비동기 스레드 격리 (boundedElastic 적용)

- 안전한 JPA 트랜잭션(롤백) 보장을 위해 DB 영속화 로직을 별도 서비스로 분리 (DiaryCommandService 신규 생성)

## 🗨️ 리뷰 요구사항(선택)
- AIService 내 flatMap 등 전반적인 비동기 체이닝 흐름이 의도대로 잘 연결되었는지 확인 부탁드립니다.

- 분리된 DiaryCommandService의 데이터 저장 흐름에 이상이 없는지 중점적으로 리뷰해 주시면 감사하겠습니다.